### PR TITLE
Suppress useLayoutEffect warning and show coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.jest/

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 
 # production
 /build
+.jest/

--- a/hooks/useTheme.js
+++ b/hooks/useTheme.js
@@ -16,7 +16,7 @@
 
 import React, { useContext } from "react";
 import PropTypes from "prop-types";
-import { LIGHT_THEME, DARK_THEME } from "utils/theme-utils";
+import { LIGHT_THEME, DARK_THEME, isServerSide } from "utils/theme-utils";
 
 const LOCAL_STORAGE_THEME_KEY = "rode-ui-theme";
 
@@ -27,8 +27,9 @@ const ThemeContext = React.createContext({
 
 export const ThemeProvider = (props) => {
   const [theme, setTheme] = React.useState(LIGHT_THEME);
+  const useEffect = isServerSide() ? React.useEffect : React.useLayoutEffect;
 
-  React.useLayoutEffect(() => {
+  useEffect(() => {
     const savedTheme = localStorage.getItem(LOCAL_STORAGE_THEME_KEY);
 
     setTheme(savedTheme);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,17 @@
     "prettier": "^2.2.1"
   },
   "jest": {
+    "collectCoverage": true,
+    "coverageDirectory": ".jest/coverage",
+    "cacheDirectory": ".jest/cache",
+    "collectCoverageFrom": [
+      "**/*.js",
+      "!.eslintrc.js",
+      "!**/node_modules/**",
+      "!**/.next/**",
+      "!**/.jest/",
+      "!**test/**"
+    ],
     "moduleNameMapper": {
       "\\.(css|scss|sass)$": "identity-obj-proxy"
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "!.eslintrc.js",
       "!**/node_modules/**",
       "!**/.next/**",
-      "!**/.jest/",
+      "!**/.jest/**",
       "!**test/**"
     ],
     "moduleNameMapper": {

--- a/utils/theme-utils.js
+++ b/utils/theme-utils.js
@@ -16,3 +16,5 @@
 
 export const LIGHT_THEME = "lightTheme";
 export const DARK_THEME = "darkTheme";
+
+export const isServerSide = () => typeof window === "undefined";


### PR DESCRIPTION

Suppresses this warning during a server-side render by calling `useEffect` instead of `useLayoutEffect`. This is one of the mitigations listed [here](https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#option-1-convert-to-useeffect).

```
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
    at ThemeProvider (webpack-internal:///./hooks/useTheme.js:38:74)
    at MyApp (webpack-internal:///./pages/_app.js:46:3)
    at AppContainer (/Users/alex/Developer/liatrio/rode/rode-ui/node_modules/next/dist/next-server/server/render.js:25:874)
```

I also updated the Jest config to show coverage during a test run. Not enforcing any values yet, I just wanted to be able to verify while writing tests locally. 