### PR TITLE
View all Resources & Fallback on resource uri

### DIFF
--- a/components/resources/ResourceBreadcrumbs.js
+++ b/components/resources/ResourceBreadcrumbs.js
@@ -16,8 +16,16 @@
 
 import React from "react";
 import { useResources } from "providers/resources";
-import styles from "styles/modules/Resources.module.scss";
+import styles from "styles/modules/Resource.module.scss";
 import Link from "next/link";
+
+const getSearchTermText = (searchTerm) => {
+  if (searchTerm === "all") {
+    return "View all resources";
+  } else {
+    return `"${searchTerm}`;
+  }
+};
 
 const ResourceBreadcrumbs = () => {
   const {
@@ -33,7 +41,7 @@ const ResourceBreadcrumbs = () => {
       <p>Resource Search</p>
       <p>/</p>
       <Link href={`/resources?search=${encodeURIComponent(searchTerm)}`}>
-        <a>{`"${searchTerm}"`}</a>
+        <a>{getSearchTermText(searchTerm)}</a>
       </Link>
     </div>
   );

--- a/components/resources/ResourceOccurrences.js
+++ b/components/resources/ResourceOccurrences.js
@@ -23,11 +23,9 @@ import { useFetch } from "hooks/useFetch";
 const ResourceOccurrences = (props) => {
   const { resourceUri } = props;
 
-  const { data, loading } = useFetch(
-    resourceUri
-      ? `/api/occurrences?resourceUri=${encodeURIComponent(resourceUri)}`
-      : null
-  );
+  const { data, loading } = useFetch(resourceUri ? `/api/occurrences` : null, {
+    resourceUri,
+  });
   return (
     <>
       <Loading loading={loading} />

--- a/components/resources/ResourceSearchBar.js
+++ b/components/resources/ResourceSearchBar.js
@@ -17,7 +17,7 @@
 import React from "react";
 import { useRouter } from "next/router";
 import Input from "components/Input";
-import styles from "styles/modules/Resources.module.scss";
+import styles from "styles/modules/ResourceSearch.module.scss";
 import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import Button from "components/Button";

--- a/components/resources/ResourceSearchBar.js
+++ b/components/resources/ResourceSearchBar.js
@@ -37,35 +37,35 @@ const ResourceSearchBar = () => {
   };
 
   return (
-    <form
-      role="search"
-      className={styles.searchBarContainer}
-      onSubmit={onSubmit}
-    >
-      <Input
-        name={"resourceSearch"}
-        label={"Search for a resource"}
-        onChange={(e) =>
-          dispatch({
-            type: resourceActions.SET_SEARCH_TERM,
-            data: e.target.value,
-          })
-        }
-        placeholder={"Ex: alpine@sha256:etcetcetcetcetc"}
-        value={state.searchTerm}
-      />
-      <Button
-        label={"Search"}
-        buttonType={"icon"}
-        disabled={!state.searchTerm}
-        type={"submit"}
-      >
-        <Icon name={ICON_NAMES.SEARCH} size={"large"} />
-      </Button>
+    <form role="search" className={styles.resourceSearch} onSubmit={onSubmit}>
+      <div className={styles.searchBarContainer}>
+        <Input
+          name={"resourceSearch"}
+          label={"Search for a resource"}
+          onChange={(e) =>
+            dispatch({
+              type: resourceActions.SET_SEARCH_TERM,
+              data: e.target.value,
+            })
+          }
+          placeholder={"Ex: alpine@sha256:etcetcetcetcetc"}
+          value={state.searchTerm}
+        />
+        <Button
+          label={"Search"}
+          buttonType={"icon"}
+          disabled={!state.searchTerm}
+          type={"submit"}
+        >
+          <Icon name={ICON_NAMES.SEARCH} size={"large"} />
+        </Button>
+      </div>
+      <p className={styles.searchHelp}>
+        You can search by name, version, or{" "}
+        <a href={"/resources?search=all"}>view all resources</a>.
+      </p>
     </form>
   );
 };
-
-ResourceSearchBar.propTypes = {};
 
 export default ResourceSearchBar;

--- a/components/resources/ResourceSearchResult.js
+++ b/components/resources/ResourceSearchResult.js
@@ -16,7 +16,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import styles from "styles/modules/Resources.module.scss";
+import styles from "styles/modules/ResourceSearch.module.scss";
 import Button from "components/Button";
 import { useRouter } from "next/router";
 import { getResourceDetails } from "utils/resource-utils";

--- a/hooks/useFetch.js
+++ b/hooks/useFetch.js
@@ -26,10 +26,7 @@ export const useFetch = (url, query) => {
 
   const urlWithQuery = query ? `${url}?${new URLSearchParams(query)}` : url;
 
-  const { data: swrData, error: swrError } = useSWR(
-    url ? urlWithQuery : null,
-    fetcher
-  );
+  const { data: swrData, error: swrError } = useSWR(urlWithQuery, fetcher);
 
   useEffect(() => {
     if (swrData) {

--- a/hooks/useFetch.js
+++ b/hooks/useFetch.js
@@ -19,11 +19,17 @@ import { useState, useEffect } from "react";
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
-export const useFetch = (url) => {
+export const useFetch = (url, query = {}) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [data, setData] = useState(null);
-  const { data: swrData, error: swrError } = useSWR(url ? url : null, fetcher);
+
+  const urlWithQuery = query ? `${url}?${new URLSearchParams(query)}` : url;
+
+  const { data: swrData, error: swrError } = useSWR(
+    url ? urlWithQuery : null,
+    fetcher
+  );
 
   useEffect(() => {
     if (swrData) {

--- a/hooks/useFetch.js
+++ b/hooks/useFetch.js
@@ -19,7 +19,7 @@ import { useState, useEffect } from "react";
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
-export const useFetch = (url, query = {}) => {
+export const useFetch = (url, query) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [data, setData] = useState(null);

--- a/hooks/useFetch.js
+++ b/hooks/useFetch.js
@@ -20,7 +20,7 @@ import { useState, useEffect } from "react";
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
 export const useFetch = (url, query) => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [data, setData] = useState(null);
 

--- a/pages/api/resources.js
+++ b/pages/api/resources.js
@@ -29,9 +29,14 @@ export default async (req, res) => {
 
   try {
     const searchTerm = req.query.filter;
-    const filter = `"resource.uri".startsWith("${searchTerm}")`;
+    let filter = {};
+    if (searchTerm) {
+      filter = {
+        filter: `"resource.uri".startsWith("${searchTerm}")`,
+      };
+    }
     const response = await fetch(
-      `${rodeUrl}/v1alpha1/resources?filter=${encodeURIComponent(filter)}`
+      `${rodeUrl}/v1alpha1/resources?${new URLSearchParams(filter)}`
     );
 
     if (!response.ok) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,7 +15,7 @@
  */
 
 import React from "react";
-import styles from "styles/modules/Resources.module.scss";
+import styles from "styles/modules/ResourceSearch.module.scss";
 import ResourceSearchBar from "components/resources/ResourceSearchBar";
 
 const Home = () => {

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -25,6 +25,16 @@ import Loading from "components/Loading";
 import { useFetch } from "hooks/useFetch";
 import { resourceActions } from "reducers/resources";
 
+const createSearchFilter = (query) => {
+  if (query && query !== "all") {
+    return {
+      filter: query,
+    };
+  }
+
+  return null;
+};
+
 const Resources = () => {
   const { theme } = useTheme();
   const { dispatch } = useResources();
@@ -32,9 +42,7 @@ const Resources = () => {
   const router = useRouter();
   const { data, loading } = useFetch(
     router.query.search ? "/api/resources" : null,
-    {
-      filter: router.query.search,
-    }
+    createSearchFilter(router.query.search)
   );
 
   useEffect(() => {
@@ -55,9 +63,10 @@ const Resources = () => {
 
   return (
     <div
-      className={`${
-        showSearchResults ? styles.container : styles.containerNoResults
-      } ${styles[theme]}`}
+      className={`
+      ${showSearchResults ? styles.showResults : ""} 
+      ${styles[theme]} 
+      ${styles.container}`}
     >
       <ResourceSearchBar />
       {showSearchResults && (

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from "react";
 import ResourceSearchBar from "components/resources/ResourceSearchBar";
 import { useRouter } from "next/router";
-import styles from "styles/modules/Resources.module.scss";
+import styles from "styles/modules/ResourceSearch.module.scss";
 import { useTheme } from "providers/theme";
 import { useResources } from "providers/resources";
 import ResourceSearchResult from "components/resources/ResourceSearchResult";

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -31,9 +31,10 @@ const Resources = () => {
   const [showSearchResults, setShowSearchResults] = useState(false);
   const router = useRouter();
   const { data, loading } = useFetch(
-    router.query.search
-      ? `/api/resources?filter=${encodeURIComponent(router.query.search)}`
-      : null
+    router.query.search ? "/api/resources" : null,
+    {
+      filter: router.query.search,
+    }
   );
 
   useEffect(() => {

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useTheme } from "providers/theme";
-import styles from "styles/modules/Resources.module.scss";
+import styles from "styles/modules/Resource.module.scss";
 import { getResourceDetails } from "utils/resource-utils";
 import ResourceOccurrences from "components/resources/ResourceOccurrences";
 import ResourceBreadcrumbs from "components/resources/ResourceBreadcrumbs";

--- a/styles/modules/Resource.module.scss
+++ b/styles/modules/Resource.module.scss
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "styles/constants";
+@import "styles/mixins";
+
+.container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.breadcrumbs {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0.5rem 1rem;
+
+  > * {
+    padding: 0 0.25rem;
+  }
+}
+
+.resourceHeader {
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  box-shadow: $BOX_SHADOW;
+}
+
+.resourceName {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.versionContainer {
+  text-align: right;
+  margin-left: 2rem;
+  color: $SOFT_WHITE;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.darkTheme {
+  .breadcrumbs {
+    color: $MEDIUM_GREY;
+  }
+
+  .resourceHeader {
+    background-color: $DEEP_SEA;
+    > * {
+      color: $SOFT_WHITE;
+    }
+  }
+}
+
+.lightTheme {
+  .breadcrumbs {
+    color: $MEDIUM_GREY;
+  }
+
+  .resourceHeader {
+    background-color: $DEEP_SEA;
+
+    > * {
+      color: $SOFT_WHITE;
+    }
+  }
+}

--- a/styles/modules/ResourceSearch.module.scss
+++ b/styles/modules/ResourceSearch.module.scss
@@ -36,7 +36,7 @@
 
     .searchHelp {
       font-size: 0.75rem;
-      padding: 0 0.5rem;
+      padding: 0 3rem;
       color: $MEDIUM_GREY;
       text-align: right;
     }

--- a/styles/modules/ResourceSearch.module.scss
+++ b/styles/modules/ResourceSearch.module.scss
@@ -89,43 +89,6 @@
   }
 }
 
-.resourceHeader {
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  box-shadow: $BOX_SHADOW;
-
-  .resourceName {
-    font-size: 1.75rem;
-    font-weight: 700;
-  }
-
-  .versionContainer {
-    text-align: right;
-    margin-left: 2rem;
-    color: $SOFT_WHITE;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-}
-
-.breadcrumbs {
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
-  padding: 0.5rem 1rem;
-
-  > * {
-    padding: 0 0.25rem;
-  }
-}
-
 .darkTheme {
   .noResults {
     color: $SOFT_WHITE;
@@ -153,15 +116,6 @@
       color: $SILVER;
     }
   }
-
-  .resourceHeader {
-    background-color: $DEEP_SEA;
-    color: $SOFT_WHITE;
-  }
-
-  .breadcrumbs {
-    color: $MEDIUM_GREY;
-  }
 }
 
 .lightTheme {
@@ -176,14 +130,6 @@
     }
   }
 
-  .resourceHeader {
-    background-color: $DEEP_SEA;
-
-    > * {
-      color: $SOFT_WHITE;
-    }
-  }
-
   .searchCard {
     background-color: $WHITE;
 
@@ -194,9 +140,5 @@
     .cardText {
       color: $MEDIUM_GREY;
     }
-  }
-
-  .breadcrumbs {
-    color: $MEDIUM_GREY;
   }
 }

--- a/styles/modules/Resources.module.scss
+++ b/styles/modules/Resources.module.scss
@@ -17,44 +17,52 @@
 @import "styles/constants";
 @import "styles/mixins";
 
-.containerBase {
+.container {
   height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-}
-
-.searchBarContainerBase {
-  height: fit-content;
-  width: 90%;
-  margin: 1rem auto;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-self: center;
-}
-
-.containerNoResults {
-  @extend .containerBase;
   justify-content: center;
 
-  .searchBarContainer {
-    @extend .searchBarContainerBase;
+  .resourceSearch {
     width: 90%;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
 
     @include tabletAndLarger {
       width: 50%;
     }
+
+    .searchHelp {
+      font-size: 0.75rem;
+      padding: 0 0.5rem;
+      color: $MEDIUM_GREY;
+      text-align: right;
+    }
+  }
+
+  &.showResults {
+    justify-content: flex-start;
+
+    .resourceSearch {
+      width: 90%;
+
+      .searchHelp {
+        display: none;
+      }
+    }
   }
 }
 
-.container {
-  @extend .containerBase;
-  justify-content: flex-start;
-
-  .searchBarContainer {
-    @extend .searchBarContainerBase;
-  }
+.searchBarContainer {
+  height: fit-content;
+  width: 100%;
+  margin: 1rem auto 0.5rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-self: center;
 }
 
 .searchCard {

--- a/test/components/resources/ResourceBreadcrumbs.spec.js
+++ b/test/components/resources/ResourceBreadcrumbs.spec.js
@@ -53,6 +53,19 @@ describe("ResourceBreadcrumbs", () => {
         `/resources?search=${encodeURIComponent(searchTerm)}`
       );
     });
+
+    it("should return the correct breadcrumb when viewing all resources", () => {
+      useResources.mockReturnValue({
+        state: {
+          searchTerm: "all",
+        },
+      });
+
+      render(<ResourceBreadcrumbs />);
+      const renderedLink = screen.getByText(/view all resources/i);
+      expect(renderedLink).toBeInTheDocument();
+      expect(renderedLink).toHaveAttribute("href", `/resources?search=all`);
+    });
   });
 
   describe("no searchTerm exists", () => {

--- a/test/components/resources/ResourceOccurrences.spec.js
+++ b/test/components/resources/ResourceOccurrences.spec.js
@@ -33,7 +33,9 @@ describe("ResourceOccurrences", () => {
   it("should not make the fetch call if there is no resource uri specified", () => {
     useFetch.mockReturnValue({});
     render(<ResourceOccurrences resourceUri={null} />);
-    expect(useFetch).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(null);
+    expect(useFetch).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(null, {
+      resourceUri: null,
+    });
   });
 
   it("should call to fetch the occurrences is a uri is specified", () => {
@@ -41,9 +43,9 @@ describe("ResourceOccurrences", () => {
     render(<ResourceOccurrences resourceUri={resourceUri} />);
     expect(useFetch)
       .toHaveBeenCalledTimes(2)
-      .toHaveBeenCalledWith(
-        `/api/occurrences?resourceUri=${encodeURIComponent(resourceUri)}`
-      );
+      .toHaveBeenCalledWith("/api/occurrences", {
+        resourceUri,
+      });
   });
 
   it("should show a loading indicator while fetching the data", () => {

--- a/test/components/resources/ResourceSearchBar.spec.js
+++ b/test/components/resources/ResourceSearchBar.spec.js
@@ -70,6 +70,12 @@ describe("ResourceSearchBar", () => {
     expect(renderedSearchButton).toBeDisabled();
   });
 
+  it("should render some helper text", () => {
+    expect(
+      screen.getByText(/view all resources/i, { exact: false })
+    ).toBeInTheDocument();
+  });
+
   it("should enable the button when a search term is entered", () => {
     useResources.mockReturnValue({
       state: { searchTerm: chance.string() },

--- a/test/hooks/useFetch.spec.js
+++ b/test/hooks/useFetch.spec.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import FetchComponent from "test/testing-utils/useFetchComponent";
+import useSWR from "swr";
+
+jest.mock("swr");
+
+describe("useFetch", () => {
+  let url, query;
+
+  beforeEach(() => {
+    url = chance.url();
+    query = { [chance.string()]: chance.string() };
+
+    useSWR.mockReturnValue({
+      data: chance.string(),
+      error: null,
+    });
+  });
+
+  it("should use SWR to fetch data with no query", () => {
+    render(<FetchComponent url={url} query={null} />);
+
+    expect(useSWR).toHaveBeenCalledWith(url, expect.any(Function));
+  });
+
+  it("should use SWR to fetch data with a specified query", () => {
+    render(<FetchComponent url={url} query={query} />);
+
+    expect(useSWR).toHaveBeenCalledWith(
+      `${url}?${new URLSearchParams(query)}`,
+      expect.any(Function)
+    );
+  });
+
+  it("should pass null as the URL when it is not specified", () => {
+    render(<FetchComponent url={null} query={null} />);
+
+    expect(useSWR).toHaveBeenCalledWith(null, expect.any(Function));
+  });
+
+  it("should return the data if the call was successful", () => {
+    render(<FetchComponent url={url} query={query} />);
+
+    expect(screen.getByText(/data:/i)).toBeInTheDocument();
+  });
+
+  it("should return the error if an error occurs during the call", () => {
+    useSWR.mockReturnValue({
+      data: null,
+      error: chance.string(),
+    });
+
+    render(<FetchComponent url={url} query={query} />);
+
+    expect(screen.getByText(/error:/i)).toBeInTheDocument();
+  });
+
+  it("should return loading while the call is being made", () => {
+    useSWR.mockReturnValue({
+      data: null,
+      error: null,
+    });
+
+    render(<FetchComponent url={url} query={query} />);
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+});

--- a/test/hooks/useFetch.spec.js
+++ b/test/hooks/useFetch.spec.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import FetchComponent from "test/testing-utils/useFetchComponent";

--- a/test/pages/api/resources.spec.js
+++ b/test/pages/api/resources.spec.js
@@ -88,17 +88,24 @@ describe("/api/resources", () => {
       process.env.RODE_URL = rodeUrlEnv;
     });
 
-    const createExpectedUrl = (baseUrl) => {
-      const expectedFilter = `"resource.uri".startsWith("${filterParam}")`;
-
-      return `${baseUrl}/v1alpha1/resources?filter=${encodeURIComponent(
-        expectedFilter
-      )}`;
+    const createExpectedUrl = (baseUrl, query = {}) => {
+      return `${baseUrl}/v1alpha1/resources?${new URLSearchParams(query)}`;
     };
 
     it("should hit the Rode API", async () => {
+      const expectedUrl = createExpectedUrl("http://localhost:50052", {
+        filter: `"resource.uri".startsWith("${filterParam}")`,
+      });
+
+      await handler(request, response);
+
+      expect(fetch).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
+    });
+
+    it("should hit the Rode API when no filter is specified", async () => {
       const expectedUrl = createExpectedUrl("http://localhost:50052");
 
+      request.query.filter = null;
       await handler(request, response);
 
       expect(fetch).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
@@ -106,7 +113,9 @@ describe("/api/resources", () => {
 
     it("should take the Rode URL from the environment if set", async () => {
       const rodeUrl = chance.url();
-      const expectedUrl = createExpectedUrl(rodeUrl);
+      const expectedUrl = createExpectedUrl(rodeUrl, {
+        filter: `"resource.uri".startsWith("${filterParam}")`,
+      });
       process.env.RODE_URL = rodeUrl;
 
       await handler(request, response);

--- a/test/pages/resources.spec.js
+++ b/test/pages/resources.spec.js
@@ -78,15 +78,13 @@ describe("Resources", () => {
     });
 
     it("should pass the search term through as a filter", () => {
-      const expectedUri = `/api/resources?filter=${encodeURIComponent(
-        expectedSearch
-      )}`;
-
       render(<Resources />);
 
       expect(useFetch)
         .toHaveBeenCalledTimes(2)
-        .toHaveBeenCalledWith(expectedUri);
+        .toHaveBeenCalledWith("/api/resources", {
+          filter: expectedSearch,
+        });
     });
 
     it("should render all of the search results", () => {

--- a/test/pages/resources.spec.js
+++ b/test/pages/resources.spec.js
@@ -87,6 +87,19 @@ describe("Resources", () => {
         });
     });
 
+    it("should handle viewing all resources", () => {
+      useRouter.mockReturnValue({
+        query: {
+          search: "all",
+        },
+      });
+      render(<Resources />);
+
+      expect(useFetch)
+        .toHaveBeenCalledTimes(2)
+        .toHaveBeenCalledWith("/api/resources", null);
+    });
+
     it("should render all of the search results", () => {
       render(<Resources />);
 

--- a/test/testing-utils/useFetchComponent.js
+++ b/test/testing-utils/useFetchComponent.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import PropTypes from "prop-types";
 import { useFetch } from "hooks/useFetch";

--- a/test/testing-utils/useFetchComponent.js
+++ b/test/testing-utils/useFetchComponent.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useFetch } from "hooks/useFetch";
+
+const FetchComponent = ({ url, query }) => {
+  const { data, loading, error } = useFetch(url, query);
+
+  if (data) {
+    return <p>Data: {data}</p>;
+  }
+
+  if (loading) {
+    return <p>Loading</p>;
+  }
+
+  if (error) {
+    return <p>Error: {error}</p>;
+  }
+
+  return null;
+};
+
+FetchComponent.propTypes = {
+  url: PropTypes.string,
+  query: PropTypes.object,
+};
+
+export default FetchComponent;

--- a/test/utils/resource-utils.spec.js
+++ b/test/utils/resource-utils.spec.js
@@ -29,10 +29,13 @@ describe("resource utils", () => {
       resourceVersion = chance.semver();
     });
 
-    it("should return null for an unknown resource type", () => {
-      const actual = getResourceDetails(chance.url());
+    it("should return generic values for an unknown resource type", () => {
+      const resourceUri = chance.url();
+      const actual = getResourceDetails(resourceUri);
 
-      expect(actual).toBeNull();
+      expect(actual.resourceType).toBe("Unknown");
+      expect(actual.resourceName).toBe(resourceUri);
+      expect(actual.resourceVersion).toBe("N/A");
     });
 
     it("should return the correct details for a Debian Resource", () => {

--- a/utils/resource-utils.js
+++ b/utils/resource-utils.js
@@ -105,8 +105,12 @@ export const getResourceDetails = (uri) => {
   );
 
   if (!resourceMatch) {
-    console.error("Unknown resource type found");
-    return null;
+    console.log("Resource URI does not match expected format");
+    return {
+      resourceType: "Unknown",
+      resourceName: uri,
+      resourceVersion: "N/A",
+    };
   }
 
   const { name, version } = resourceMatch.parse


### PR DESCRIPTION
Closes #14 and closes #15 

* Shows the resourceUri as the whole name, and version and type will show `N/A` if the resourceUri doesn't match an expected format
* Adds a "View all resources" link below the search to help someone get started. The text is not exactly true without the `.contains` filter being surfaced through Rode yet but we'll get there soon.
* Updates `useFetch` to take in the url and an object of query params