### PR TITLE
Error Pages & Mobile improvements

### DIFF
--- a/__mocks__/next/router.js
+++ b/__mocks__/next/router.js
@@ -14,27 +14,12 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from "react";
-import styles from "styles/modules/Resources.module.scss";
-import ResourceSearchBar from "components/resources/ResourceSearchBar";
-import { useResources } from "providers/resources";
-import { resourceActions } from "reducers/resources";
-
-const Home = () => {
-  const { dispatch } = useResources();
-
-  useEffect(() => {
-    dispatch({
-      type: resourceActions.SET_SEARCH_TERM,
-      data: "",
-    });
-  }, []);
-
-  return (
-    <div className={styles.containerNoResults}>
-      <ResourceSearchBar />
-    </div>
-  );
+export const withRouter = (component) => {
+  component.defaultProps = {
+    ...component.defaultProps,
+    router: { pathname: "mocked-path", reload: jest.fn() },
+  };
+  return component;
 };
 
-export default Home;
+export const useRouter = jest.fn();

--- a/components/Button.js
+++ b/components/Button.js
@@ -17,6 +17,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Buttons.module.scss";
+import { useTheme } from "providers/theme";
 
 const Button = (props) => {
   const {
@@ -28,9 +29,11 @@ const Button = (props) => {
     ...otherProps
   } = props;
 
+  const { theme } = useTheme();
+
   return (
     <button
-      className={styles[buttonType]}
+      className={`${styles[buttonType]} ${styles[theme]}`}
       onClick={onClick}
       aria-label={label}
       disabled={disabled}

--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import styles from "styles/modules/Errors.module.scss";
+import Button from "./Button";
+import { withRouter } from "next/router";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className={styles.boundaryContainer}>
+          <p>{"Something went wrong."}</p>
+          <Button
+            onClick={() => {
+              this.setState({
+                hasError: false,
+                error: null,
+              });
+              this.props.router.reload();
+            }}
+            label={"Refresh"}
+          />
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+  router: PropTypes.object.isRequired,
+};
+
+export default withRouter(ErrorBoundary);

--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -37,7 +37,7 @@ class ErrorBoundary extends React.Component {
   render() {
     if (this.state.hasError) {
       return (
-        <div className={styles.boundaryContainer}>
+        <div className={styles.container}>
           <p>{"Something went wrong."}</p>
           <Button
             onClick={() => {

--- a/components/layout/PageLayout.js
+++ b/components/layout/PageLayout.js
@@ -18,13 +18,16 @@ import React from "react";
 import PropTypes from "prop-types";
 import Header from "./Header";
 import { useTheme } from "providers/theme";
+import ErrorBoundary from "components/ErrorBoundary";
 
 const PageLayout = ({ children }) => {
   const { theme } = useTheme();
   return (
     <>
       <Header />
-      <main className={theme}>{children}</main>
+      <main className={theme}>
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </main>
     </>
   );
 };

--- a/components/resources/ResourceOccurrences.js
+++ b/components/resources/ResourceOccurrences.js
@@ -33,7 +33,7 @@ const ResourceOccurrences = (props) => {
       <Loading loading={loading} />
       {data && (
         <>
-          {data?.map((occurrence) => (
+          {data.map((occurrence) => (
             <ResourceOccurrenceCard
               key={occurrence.name}
               occurrence={occurrence}

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,12 @@
+import React from "react";
+import styles from "styles/modules/Errors.module.scss";
+
+const Custom404 = () => {
+  return (
+    <div className={styles.container}>
+      <p>404 - Page Not Found</p>
+    </div>
+  );
+};
+
+export default Custom404;

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -15,14 +15,28 @@
  */
 
 import React from "react";
+import PropTypes from "prop-types";
 import styles from "styles/modules/Errors.module.scss";
 
-const Custom404 = () => {
+const Error = ({ statusCode }) => {
   return (
     <div className={styles.container}>
-      <p>404 - Page Not Found</p>
+      <p>
+        {statusCode
+          ? `An error ${statusCode} occurred on server.`
+          : "An error occurred on client."}
+      </p>
     </div>
   );
 };
 
-export default Custom404;
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+Error.propTypes = {
+  statusCode: PropTypes.string.isRequired,
+};
+
+export default Error;

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -52,7 +52,7 @@ const Resource = () => {
           <p>Type: {resourceType}</p>
         </div>
         <div className={styles.versionContainer}>
-          <p>Version: {resourceVersion}</p>
+          <p className={styles.version}>Version: {resourceVersion}</p>
         </div>
       </div>
 

--- a/styles/modules/Buttons.module.scss
+++ b/styles/modules/Buttons.module.scss
@@ -72,31 +72,64 @@
   background-color: transparent;
   border-radius: 50%;
 
-  svg {
-    color: $DEEP_SEA;
-    @include transition;
-  }
-
-  &:hover,
-  &:focus {
-    background-color: $DEEP_SEA;
+  &.darkTheme {
     svg {
-      color: $WHITE;
-    }
-  }
-
-  &[disabled] {
-    background-color: transparent;
-
-    svg {
-      color: $SILVER;
+      color: $LAGOON;
+      @include transition;
     }
 
     &:hover,
     &:focus {
+      background-color: $DEEP_SEA;
+      svg {
+        color: $WHITE;
+      }
+    }
+
+    &[disabled] {
       background-color: transparent;
+
+      svg {
+        color: $MEDIUM_GREY;
+      }
+
+      &:hover,
+      &:focus {
+        background-color: transparent;
+        svg {
+          color: $MEDIUM_GREY;
+        }
+      }
+    }
+  }
+
+  &.lightTheme {
+    svg {
+      color: $DEEP_SEA;
+      @include transition;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: $DEEP_SEA;
+      svg {
+        color: $WHITE;
+      }
+    }
+
+    &[disabled] {
+      background-color: transparent;
+
       svg {
         color: $SILVER;
+      }
+
+      &:hover,
+      &:focus {
+        background-color: transparent;
+        svg {
+          color: $SILVER;
+        }
       }
     }
   }

--- a/styles/modules/Errors.module.scss
+++ b/styles/modules/Errors.module.scss
@@ -1,0 +1,11 @@
+.boundaryContainer {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  > * {
+    margin: 0.5rem;
+  }
+}

--- a/styles/modules/Resource.module.scss
+++ b/styles/modules/Resource.module.scss
@@ -54,12 +54,20 @@
 }
 
 .versionContainer {
-  text-align: right;
   margin-left: 2rem;
+}
+
+.version {
+  text-align: right;
   color: $SOFT_WHITE;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  max-width: calc(75vw - 2rem);
+
+  @include phoneAndSmaller {
+    max-width: calc(50vw - 2rem);
+  }
 }
 
 .darkTheme {

--- a/styles/modules/ResourceSearch.module.scss
+++ b/styles/modules/ResourceSearch.module.scss
@@ -94,20 +94,6 @@
     color: $SOFT_WHITE;
   }
 
-  .searchBarContainer {
-    button:not([disabled]) {
-      svg {
-        color: $LAGOON;
-      }
-
-      &:hover, &:focus {
-        svg {
-          color: $WHITE;
-        }
-      }
-    }
-  }
-
   .searchCard {
     background-color: $DARK_GREY;
 
@@ -122,20 +108,6 @@
 }
 
 .lightTheme {
-  .searchBarContainer {
-    button:not([disabled]) {
-      svg {
-        color: $DEEP_SEA;
-      }
-
-      &:hover, &:focus {
-        svg {
-          color: $WHITE;
-        }
-      }
-    }
-  }
-
   .searchCard {
     background-color: $WHITE;
 

--- a/styles/modules/ResourceSearch.module.scss
+++ b/styles/modules/ResourceSearch.module.scss
@@ -36,7 +36,7 @@
 
     .searchHelp {
       font-size: 0.75rem;
-      padding: 0 3rem;
+      padding: 0 3rem 0 0;
       color: $MEDIUM_GREY;
       text-align: right;
     }
@@ -86,6 +86,11 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+    max-width: calc(100vw - 13rem);
+
+    @include tabletAndLarger {
+      max-width: calc(100vw - 18rem);
+    }
   }
 }
 

--- a/test/ErrorBoundary.spec.js
+++ b/test/ErrorBoundary.spec.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ErrorBoundary from "components/ErrorBoundary";
+
+jest.mock("next/router");
+
+describe("ErrorBoundary", () => {
+  let reloadMock;
+
+  beforeEach(() => {
+    reloadMock = jest.fn();
+
+    const ChildComponent = () => {
+      throw new Error("oh no");
+    };
+
+    render(
+      <ErrorBoundary router={{ reload: reloadMock }}>
+        <ChildComponent />
+      </ErrorBoundary>
+    );
+  });
+
+  it("should catch the error and show the generic error screen", () => {
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+
+    const renderedButton = screen.getByText("Refresh");
+    expect(renderedButton).toBeInTheDocument();
+    userEvent.click(renderedButton);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/Button.spec.js
+++ b/test/components/Button.spec.js
@@ -18,11 +18,18 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import Button from "components/Button";
 import userEvent from "@testing-library/user-event";
+import { useTheme } from "providers/theme";
+import { DARK_THEME, LIGHT_THEME } from "utils/theme-utils";
+
+jest.mock("providers/theme");
 
 describe("Button", () => {
   let onClick, label;
 
   beforeEach(() => {
+    useTheme.mockReturnValue({
+      theme: chance.pickone([LIGHT_THEME, DARK_THEME]),
+    });
     onClick = jest.fn();
     label = chance.string();
     console.error = jest.fn();

--- a/test/components/resources/ResourceSearchBar.spec.js
+++ b/test/components/resources/ResourceSearchBar.spec.js
@@ -36,7 +36,7 @@ describe("ResourceSearchBar", () => {
     });
 
     useResources.mockReturnValue({
-      state: {},
+      state: { searchTerm: "" },
       dispatch: dispatchMock,
     });
 

--- a/test/pages/404.spec.js
+++ b/test/pages/404.spec.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-.container {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Custom404 from "pages/404";
 
-  > * {
-    margin: 0.5rem;
-  }
-}
+describe("404", () => {
+  it("should render the not found message", () => {
+    render(<Custom404 />);
+
+    expect(screen.getByText("404 - Page Not Found")).toBeInTheDocument();
+  });
+});

--- a/test/pages/_error.spec.js
+++ b/test/pages/_error.spec.js
@@ -15,14 +15,21 @@
  */
 
 import React from "react";
-import styles from "styles/modules/Errors.module.scss";
+import { render, screen } from "@testing-library/react";
+import Error from "pages/_error";
 
-const Custom404 = () => {
-  return (
-    <div className={styles.container}>
-      <p>404 - Page Not Found</p>
-    </div>
-  );
-};
+describe("CustomError", () => {
+  it("should display an error that occurred on the server", () => {
+    const statusCode = chance.natural({min: 100, max: 500});
 
-export default Custom404;
+    render(<Error statusCode={statusCode}/>);
+
+    expect(screen.getByText(`An error ${statusCode} occurred on server.`)).toBeInTheDocument();
+  });
+
+  it("should display an error that occurred on the client", () => {
+    render(<Error/>);
+
+    expect(screen.getByText('An error occurred on client.')).toBeInTheDocument();
+  });
+});

--- a/test/pages/_error.spec.js
+++ b/test/pages/_error.spec.js
@@ -20,16 +20,20 @@ import Error from "pages/_error";
 
 describe("CustomError", () => {
   it("should display an error that occurred on the server", () => {
-    const statusCode = chance.natural({min: 100, max: 500});
+    const statusCode = chance.natural({ min: 100, max: 500 });
 
-    render(<Error statusCode={statusCode}/>);
+    render(<Error statusCode={statusCode} />);
 
-    expect(screen.getByText(`An error ${statusCode} occurred on server.`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`An error ${statusCode} occurred on server.`)
+    ).toBeInTheDocument();
   });
 
   it("should display an error that occurred on the client", () => {
-    render(<Error/>);
+    render(<Error />);
 
-    expect(screen.getByText('An error occurred on client.')).toBeInTheDocument();
+    expect(
+      screen.getByText("An error occurred on client.")
+    ).toBeInTheDocument();
   });
 });

--- a/test/pages/_error.spec.js
+++ b/test/pages/_error.spec.js
@@ -19,6 +19,10 @@ import { render, screen } from "@testing-library/react";
 import Error from "pages/_error";
 
 describe("CustomError", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("should display an error that occurred on the server", () => {
     const statusCode = chance.natural({ min: 100, max: 500 });
 
@@ -35,5 +39,37 @@ describe("CustomError", () => {
     expect(
       screen.getByText("An error occurred on client.")
     ).toBeInTheDocument();
+  });
+
+  describe("getInitialProps", () => {
+    let res, err;
+
+    beforeEach(() => {
+      res = null;
+      err = null;
+    });
+
+    it("should return a 404 if no status code is specified", () => {
+      const actual = Error.getInitialProps({ res, err });
+      expect(actual.statusCode).toBe(404);
+    });
+
+    it("should return the response status code if it exists", () => {
+      res = {
+        statusCode: chance.natural({ min: 100, max: 500 }),
+      };
+
+      const actual = Error.getInitialProps({ res, err });
+      expect(actual.statusCode).toBe(res.statusCode);
+    });
+
+    it("should return the error status code if it exists and response status code does not", () => {
+      err = {
+        statusCode: chance.natural({ min: 100, max: 500 }),
+      };
+
+      const actual = Error.getInitialProps({ res, err });
+      expect(actual.statusCode).toBe(err.statusCode);
+    });
   });
 });

--- a/test/pages/resources.spec.js
+++ b/test/pages/resources.spec.js
@@ -35,7 +35,7 @@ describe("Resources", () => {
 
     useResources.mockReturnValue({
       dispatch: jest.fn(),
-      state: {},
+      state: { searchTerm: "" },
     });
 
     useFetch.mockReturnValue({});


### PR DESCRIPTION
* Adds error boundary to the whole app
* Adds custom error pages that show the same content as before, but now they follow the theme coloring so you won't get accidentally blinded
* Cut version off by adding ellipsis when it is too wide for your screen
* Fixes some icon button disabled styles


The error pages are super bare bones right now - if anyone has strong feelings about the error message we show let me know. Not sure if you guys like conversation messages like "Oops, something's not right here" or if people hate those. I was thinking it would be cool to get a graphic for the 404 page that looks like an anchor detached from a boat so we could stick with the Rode/anchor/ship theme.