### PR TITLE
Search for resources using .contains filter

### DIFF
--- a/pages/api/resources.js
+++ b/pages/api/resources.js
@@ -32,7 +32,7 @@ export default async (req, res) => {
     let filter = {};
     if (searchTerm) {
       filter = {
-        filter: `"resource.uri".startsWith("${searchTerm}")`,
+        filter: `"resource.uri".contains("${searchTerm}")`,
       };
     }
     const response = await fetch(

--- a/test/pages/api/resources.spec.js
+++ b/test/pages/api/resources.spec.js
@@ -94,7 +94,7 @@ describe("/api/resources", () => {
 
     it("should hit the Rode API", async () => {
       const expectedUrl = createExpectedUrl("http://localhost:50052", {
-        filter: `"resource.uri".startsWith("${filterParam}")`,
+        filter: `"resource.uri".contains("${filterParam}")`,
       });
 
       await handler(request, response);
@@ -114,7 +114,7 @@ describe("/api/resources", () => {
     it("should take the Rode URL from the environment if set", async () => {
       const rodeUrl = chance.url();
       const expectedUrl = createExpectedUrl(rodeUrl, {
-        filter: `"resource.uri".startsWith("${filterParam}")`,
+        filter: `"resource.uri".contains("${filterParam}")`,
       });
       process.env.RODE_URL = rodeUrl;
 


### PR DESCRIPTION
Dependent on [this PR in Rode](https://github.com/rode/rode/pull/32) to work.