### PR TITLE
Handle critical and unspecified severities

### DIFF
--- a/components/occurrences/VulnerabilityOccurrenceDetails.js
+++ b/components/occurrences/VulnerabilityOccurrenceDetails.js
@@ -28,7 +28,7 @@ const getIconRepresentation = (severity) => {
 
   if (severity === "MEDIUM") {
     iconCount = 2;
-  } else if (severity === "HIGH") {
+  } else if (severity === "HIGH" || severity === "CRITICAL") {
     iconCount = 3;
   }
 
@@ -65,7 +65,12 @@ const VulnerabilityOccurrenceDetails = ({ occurrence }) => {
             <div className={styles.vulnerabilityCardHeader}>
               <p className={styles.cardTitle}>Package: {vuln.packageName}</p>
               <div className={styles.severity}>
-                <p>Severity {vuln.effectiveSeverity}</p>
+                <p>
+                  Severity{" "}
+                  {vuln.effectiveSeverity === "SEVERITY_UNSPECIFIED"
+                    ? "N/A"
+                    : vuln.effectiveSeverity}
+                </p>
                 {getIconRepresentation(vuln.effectiveSeverity)}
               </div>
             </div>

--- a/styles/modules/OccurrenceDetails.module.scss
+++ b/styles/modules/OccurrenceDetails.module.scss
@@ -122,6 +122,16 @@ $SIDE_SPACING: 1rem;
   color: $HOT_RED;
 }
 
+.critical {
+  @extend .severity;
+  color: #f02719;
+}
+
+.severity_unspecified {
+  @extend .severity;
+  color: $MEDIUM_GREY;
+}
+
 .codeBlockContainer {
   display: flex;
   flex-direction: column;

--- a/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
+++ b/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
@@ -122,5 +122,12 @@ describe("VulnerabilityOccurrenceDetails", () => {
         expect(renderedLink).toHaveAttribute("href", url.url);
       });
     });
+
+    it("should show 'N/A' for unspecified severities", () => {
+      occurrence.vulnerabilities[0].effectiveSeverity = "SEVERITY_UNSPECIFIED";
+      rerender(<VulnerabilityOccurrenceDetails occurrence={occurrence} />);
+
+      expect(screen.getByText(/severity n\/a/i)).toBeInTheDocument();
+    });
   });
 });

--- a/test/testing-utils/mocks.js
+++ b/test/testing-utils/mocks.js
@@ -163,8 +163,13 @@ export const createMockMappedVulnerabilityOccurrence = () => {
         name: chance.string(),
         type: chance.string(),
         cvssScore: chance.d10(),
-        severity: chance.pickone(["HIGH", "MEDIUM", "LOW"]),
-        effectiveSeverity: chance.pickone(["HIGH", "MEDIUM", "LOW"]),
+        severity: chance.pickone(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
+        effectiveSeverity: chance.pickone([
+          "CRITICAL",
+          "HIGH",
+          "MEDIUM",
+          "LOW",
+        ]),
         description: chance.pickone([chance.sentence(), null]),
         relatedUrls: chance.pickone([
           chance.n(() => ({ url: chance.url() }), chance.d4()),


### PR DESCRIPTION
Did not look at the documentation close enough to see what we have enums for severity, so now we should be showing all severity levels correctly