### PR TITLE
Evaluation Playground Part II

### DIFF
--- a/components/playground/EvaluationResult.js
+++ b/components/playground/EvaluationResult.js
@@ -14,16 +14,23 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Playground.module.scss";
 import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
+import Button from "components/Button";
 
 const EvaluationResult = ({ results }) => {
+  const [showCode, setShowCode] = useState(false);
+
   if (!results) {
     return null;
   }
+
+  const toggle = () => {
+    setShowCode(!showCode);
+  };
 
   return (
     <div className={styles.evaluationResultsContainer}>
@@ -33,14 +40,21 @@ const EvaluationResult = ({ results }) => {
           <p>The resource passed the policy.</p>
         </div>
       ) : (
-        <div>
+        <div className={styles.failedEvaluationResultsContainer}>
           <div className={styles.failedEvaluationResults}>
             <Icon name={ICON_NAMES.EXCLAMATION} />
             <p>The resource failed the policy.</p>
           </div>
-          <pre>
-            <code>{results.explanation}</code>
-          </pre>
+          <Button
+            onClick={toggle}
+            label={showCode ? "Hide Failures" : "Show Failures"}
+            buttonType={"text"}
+          />
+          {showCode && (
+            <pre data-testid="codeBlock">
+              <code>{JSON.stringify(results.explanation, null, 2)}</code>
+            </pre>
+          )}
         </div>
       )}
     </div>

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -85,8 +85,7 @@ const PolicyEvaluationPlayground = () => {
       data: "",
     });
 
-    // TODO: this will need to change when we go from resource/policy details to here
-    resetPlayground();
+    setEvaluationResults(null);
   }, []);
 
   return (

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -23,10 +23,13 @@ import { useTheme } from "providers/theme";
 import PolicyBreadcrumbs from "components/policies/PolicyBreadcrumbs";
 import Button from "components/Button";
 import { usePolicy } from "hooks/usePolicy";
+import { usePolicies } from "providers/policies";
+import { policyActions } from "reducers/policies";
 
 const Policy = () => {
   const router = useRouter();
   const { theme } = useTheme();
+  const { dispatch } = usePolicies();
 
   const { id } = router.query;
 
@@ -34,6 +37,14 @@ const Policy = () => {
 
   const editPolicy = () => {
     router.push(`/policies/${id}/edit`);
+  };
+
+  const evaluateInPlayground = () => {
+    dispatch({
+      type: policyActions.SET_EVALUATION_POLICY,
+      data: policy,
+    });
+    router.push("/playground");
   };
 
   return (
@@ -52,6 +63,12 @@ const Policy = () => {
                 </div>
                 <Button label={"Edit Policy"} onClick={editPolicy} />
               </div>
+              <Button
+                label={"Evaluate in Policy Playground"}
+                buttonType={"text"}
+                onClick={evaluateInPlayground}
+                className={styles.playgroundButton}
+              />
               <div className={styles.regoContainer}>
                 <p>Rego Policy Code</p>
                 <pre>

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -23,10 +23,14 @@ import ResourceOccurrences from "components/resources/ResourceOccurrences";
 import ResourceBreadcrumbs from "components/resources/ResourceBreadcrumbs";
 import { useResources } from "providers/resources";
 import { resourceActions } from "reducers/resources";
+import Button from "components/Button";
+import { policyActions } from "reducers/policies";
+import { usePolicies } from "providers/policies";
 
 const Resource = () => {
   const { theme } = useTheme();
   const { dispatch } = useResources();
+  const { dispatch: policyDispatch } = usePolicies();
   const router = useRouter();
   const [resourceName, setResourceName] = useState("");
   const [resourceVersion, setResourceVersion] = useState("");
@@ -51,6 +55,18 @@ const Resource = () => {
     setResourceType(type);
   }, [resourceUri]);
 
+  const evaluateInPlayground = () => {
+    policyDispatch({
+      type: policyActions.SET_EVALUATION_RESOURCE,
+      data: {
+        uri: resourceUri,
+        name: resourceName,
+        version: resourceVersion,
+      },
+    });
+    router.push("/playground");
+  };
+
   return (
     <div className={`${styles[theme]} ${styles.container}`}>
       <ResourceBreadcrumbs />
@@ -63,7 +79,13 @@ const Resource = () => {
           <p className={styles.version}>Version: {resourceVersion}</p>
         </div>
       </div>
-
+      <div className={styles.playgroundContainer}>
+        <Button
+          label={"Evaluate in Policy Playground"}
+          onClick={evaluateInPlayground}
+          className={styles.playgroundButton}
+        />
+      </div>
       <ResourceOccurrences resourceUri={resourceUri} />
     </div>
   );

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -84,6 +84,7 @@ const Resource = () => {
           label={"Evaluate in Policy Playground"}
           onClick={evaluateInPlayground}
           className={styles.playgroundButton}
+          buttonType={"text"}
         />
       </div>
       <ResourceOccurrences resourceUri={resourceUri} />

--- a/styles/modules/Playground.module.scss
+++ b/styles/modules/Playground.module.scss
@@ -201,13 +201,18 @@ $CARD_WIDTH: 97%;
   @extend .evaluationResults;
 }
 
+.failedEvaluationResultsContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  > button {
+    margin: 0.5rem auto;
+  }
+}
+
 .evaluationResultsContainer {
   padding: 1rem;
-
-  pre {
-    width: 75%;
-    margin: 0 auto;
-  }
 }
 
 .darkTheme {

--- a/styles/modules/Policy.module.scss
+++ b/styles/modules/Policy.module.scss
@@ -236,6 +236,10 @@
   max-width: 100%;
 }
 
+.playgroundButton {
+  align-self: flex-end;
+}
+
 .regoContainer {
   margin: 2rem 0 0;
 }

--- a/styles/modules/Resource.module.scss
+++ b/styles/modules/Resource.module.scss
@@ -60,6 +60,22 @@
   }
 }
 
+.playgroundContainer {
+  height: 0.25rem;
+  width: 100%;
+  position: relative;
+}
+.playgroundButton {
+  margin: 1rem auto;
+
+  @include tabletAndLarger {
+    margin: 0 0 0 auto;
+    position: relative;
+    top: 0.5rem;
+    right: 0.5rem;
+  }
+}
+
 .darkTheme {
   .resourceHeader {
     background-color: $DEEP_SEA;

--- a/test/components/playground/EvaluationResult.spec.js
+++ b/test/components/playground/EvaluationResult.spec.js
@@ -17,6 +17,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import EvaluationResult from "components/playground/EvaluationResult";
+import userEvent from "@testing-library/user-event";
 
 describe("EvaluationResult", () => {
   it("should return null when there are no results", () => {
@@ -48,6 +49,20 @@ describe("EvaluationResult", () => {
       screen.getByText(/the resource failed the policy/i)
     ).toBeInTheDocument();
     expect(screen.getByTitle(/exclamation/i)).toBeInTheDocument();
-    expect(screen.getByText(failedResult.explanation)).toBeInTheDocument();
+
+    const renderedToggleCodeButton = screen.getByRole("button", {
+      name: "Show Failures",
+    });
+    expect(renderedToggleCodeButton).toBeInTheDocument();
+
+    userEvent.click(renderedToggleCodeButton);
+
+    expect(screen.getByTestId("codeBlock")).toBeInTheDocument();
+    expect(
+      screen.getByText(JSON.stringify(failedResult.explanation, null, 2))
+    ).toBeInTheDocument();
+    userEvent.click(screen.getByRole("button", { name: "Hide Failures" }));
+
+    expect(screen.queryByTestId("codeBlock")).not.toBeInTheDocument();
   });
 });

--- a/test/pages/playground.spec.js
+++ b/test/pages/playground.spec.js
@@ -79,7 +79,7 @@ describe("PolicyEvaluationPlayground", () => {
         type: "SET_SEARCH_TERM",
         data: "",
       });
-      expect(policyDispatch).toHaveBeenCalledTimes(3).toHaveBeenCalledWith({
+      expect(policyDispatch).toHaveBeenCalledTimes(1).toHaveBeenCalledWith({
         type: "SET_SEARCH_TERM",
         data: "",
       });

--- a/test/pages/policies/[id].spec.js
+++ b/test/pages/policies/[id].spec.js
@@ -91,6 +91,22 @@ describe("Policy Details", () => {
         .toHaveBeenCalledTimes(1)
         .toHaveBeenCalledWith(`/policies/${policy.id}/edit`);
     });
+
+    it("should render a button to evaluate the policy in the playground", () => {
+      const renderedButton = screen.getByRole("button", {
+        name: "Evaluate in Policy Playground",
+      });
+
+      expect(renderedButton).toBeInTheDocument();
+      userEvent.click(renderedButton);
+      expect(dispatchMock).toHaveBeenCalledTimes(1).toHaveBeenCalledWith({
+        type: "SET_EVALUATION_POLICY",
+        data: policy,
+      });
+      expect(router.push)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith("/playground");
+    });
   });
 
   describe("policy was not found", () => {

--- a/test/pages/resources/[resourceUri].spec.js
+++ b/test/pages/resources/[resourceUri].spec.js
@@ -32,7 +32,7 @@ describe("Resource Details page", () => {
       query: {
         resourceUri: createMockResourceUri(),
       },
-      push: jest.fn()
+      push: jest.fn(),
     };
     state = {
       searchTerm: chance.string(),
@@ -42,13 +42,17 @@ describe("Resource Details page", () => {
     resourceDispatch = jest.fn();
 
     useRouter.mockReturnValue(router);
-    render(<Resource />, { resourceState: state, resourceDispatch, policyDispatch });
+    render(<Resource />, {
+      resourceState: state,
+      resourceDispatch,
+      policyDispatch,
+    });
   });
 
   it("should clear the occurrence details on load", () => {
     expect(resourceDispatch).toHaveBeenCalledWith({
-      type: 'SET_OCCURRENCE_DETAILS',
-      data: null
+      type: "SET_OCCURRENCE_DETAILS",
+      data: null,
     });
   });
 
@@ -67,21 +71,26 @@ describe("Resource Details page", () => {
       router.query.resourceUri
     );
 
-    const renderedButton = screen.getByRole("button", {name: "Evaluate in Policy Playground"});
+    const renderedButton = screen.getByRole("button", {
+      name: "Evaluate in Policy Playground",
+    });
 
     expect(renderedButton).toBeInTheDocument();
     userEvent.click(renderedButton);
 
-    expect(policyDispatch).toHaveBeenCalledTimes(1)
+    expect(policyDispatch)
+      .toHaveBeenCalledTimes(1)
       .toHaveBeenCalledWith({
-        type: 'SET_EVALUATION_RESOURCE',
+        type: "SET_EVALUATION_RESOURCE",
         data: {
           uri: router.query.resourceUri,
           name: resourceName,
-          version: resourceVersion
-        }
+          version: resourceVersion,
+        },
       });
 
-    expect(router.push).toHaveBeenCalledTimes(1).toHaveBeenCalledWith("/playground");
+    expect(router.push)
+      .toHaveBeenCalledTimes(1)
+      .toHaveBeenCalledWith("/playground");
   });
 });

--- a/test/testing-utils/mocks.js
+++ b/test/testing-utils/mocks.js
@@ -21,7 +21,7 @@ const chance = new Chance();
 const createBuiltArtifacts = () => ({
   checksum: chance.natural(),
   id: chance.guid(),
-  names: [chance.word({ syllable: chance.d10() + 3 })],
+  names: [chance.word({ syllables: chance.d10() + 3 })],
 });
 
 const createDiscoveryDetails = () => ({


### PR DESCRIPTION
Probably could have put this in the last PR but 🤷 it seemed like a natural break.

* Adds button to resource details and policy details to "Evaluate in Policy Playground" - auto populates the selected item
* Changes the evaluation failure to have a toggle-able code block showing the failed evaluation explanation
