### PR TITLE
Include groupId in resource name for Maven resources

### DIFF
--- a/test/utils/resource-utils.spec.js
+++ b/test/utils/resource-utils.spec.js
@@ -74,11 +74,10 @@ describe("resource utils", () => {
     });
 
     it("should return the correct details for a Maven Resource", () => {
-      const url = createGenericResourceUrl(
-        resourceName,
-        resourceVersion,
-        "gav://"
-      );
+      const groupId = chance.word();
+      const artifactId = chance.word();
+      const url = `gav://${groupId}:${artifactId}:${resourceVersion}`;
+      const resourceName = `${groupId}:${artifactId}`;
       const actual = getResourceDetails(url);
 
       expect(actual.resourceType).toBe("Maven");

--- a/utils/resource-utils.js
+++ b/utils/resource-utils.js
@@ -21,7 +21,6 @@ const GIT_REGEXP = "^(git:/{2})(.+)@(.+)";
 export const parseGeneric = (uri) => {
   // deb://dist(optional):arch:name:version
   // rpm://dist(optional):arch:name:version
-  // gav://group:artifact:version
   // npm://package:version
   // nuget://module:version
   // pip://package:version
@@ -31,6 +30,16 @@ export const parseGeneric = (uri) => {
   return {
     name: uriParts[uriParts.length - 2],
     version: uriParts[uriParts.length - 1],
+  };
+};
+
+const parseMaven = (uri) => {
+  // gav://group:artifact:version
+  const [groupId, artifactId, version] = uri.slice("gav://".length).split(":");
+
+  return {
+    name: `${groupId}:${artifactId}`,
+    version: version,
   };
 };
 
@@ -91,6 +100,7 @@ const resourceUrlTypes = [
   {
     type: "Maven",
     regex: "^(gav:/{2})",
+    parse: parseMaven,
   },
   {
     type: "NPM",


### PR DESCRIPTION
As part of https://github.com/rode/rode/pull/48, I realized we should probably include the `groupId` as part of the resource name for Maven artifacts. Without it there's likely to be conflicts when artifacts have the same id. 

For an example of this happening, here's two packages with the same `artifactId`: [`org.eclipse.core:runtime`](https://mvnrepository.com/artifact/org.eclipse.core/runtime/3.10.0-v20140318-2214) and [`android.arch.persistence.room:runtime`](https://mvnrepository.com/artifact/android.arch.persistence.room/runtime/1.1.1). 