### PR TITLE
Playground & Policy CRUD E2E Tests

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -65,6 +65,7 @@ Button.propTypes = {
     "text",
     "textDestructive",
     "primaryDestructive",
+    "modalClose",
   ]),
   children: PropTypes.node,
   className: PropTypes.string,

--- a/components/policies/PolicySearchBar.js
+++ b/components/policies/PolicySearchBar.js
@@ -43,6 +43,7 @@ const PolicySearchBar = ({ onSubmit, helpText, onChange }) => {
       searchTerm={state.searchTerm}
       placeholder={"Ex: max-severe-vulnerabilities"}
       helpText={helpText}
+      buttonLabel={"Search Policies"}
     />
   );
 };

--- a/components/resources/ResourceSearchBar.js
+++ b/components/resources/ResourceSearchBar.js
@@ -43,6 +43,7 @@ const ResourceSearchBar = ({ onSubmit, helpText, onChange }) => {
       searchTerm={state.searchTerm}
       placeholder={"ex: alpine@sha256:etcetcetc"}
       helpText={helpText}
+      buttonLabel={"Search Resources"}
     />
   );
 };

--- a/components/shared/search/SearchBar.js
+++ b/components/shared/search/SearchBar.js
@@ -31,6 +31,7 @@ const SearchBar = (props) => {
     name,
     placeholder,
     helpText,
+    buttonLabel,
   } = props;
 
   return (
@@ -44,7 +45,7 @@ const SearchBar = (props) => {
           value={searchTerm}
         />
         <Button
-          label={"Search"}
+          label={buttonLabel || "Search"}
           buttonType={"icon"}
           disabled={!searchTerm?.length}
           type={"submit"}
@@ -65,6 +66,7 @@ SearchBar.propTypes = {
   searchTerm: PropTypes.string,
   placeholder: PropTypes.string,
   helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  buttonLabel: PropTypes.string,
 };
 
 export default SearchBar;

--- a/cypress/integration/Policy/policy-crud.spec.js
+++ b/cypress/integration/Policy/policy-crud.spec.js
@@ -156,7 +156,7 @@ context("Policy CRUD", () => {
     });
   });
 
-  context.only("Delete a Policy", () => {
+  context("Delete a Policy", () => {
     beforeEach(() => {
       cy.mockRequest(
         { url: "**/api/policies/*", method: "GET" },

--- a/cypress/integration/Policy/policy-crud.spec.js
+++ b/cypress/integration/Policy/policy-crud.spec.js
@@ -90,7 +90,7 @@ context("Policy CRUD", () => {
     });
   });
 
-  context.only("Edit a Policy", () => {
+  context("Edit a Policy", () => {
     beforeEach(() => {
       cy.mockRequest(
         { url: "**/api/policies/*", method: "GET" },
@@ -153,6 +153,63 @@ context("Policy CRUD", () => {
         "match",
         new RegExp(`/policies/${mockMappedPolicy[0].id}`)
       );
+    });
+  });
+
+  context.only("Delete a Policy", () => {
+    beforeEach(() => {
+      cy.mockRequest(
+        { url: "**/api/policies/*", method: "GET" },
+        mockMappedPolicy[0]
+      );
+
+      cy.visit(`/policies/${mockMappedPolicy[0].id}`);
+      cy.contains("Edit Policy").click();
+
+      cy.url().should(
+        "match",
+        new RegExp(`/policies/${mockMappedPolicy[0].id}/edit`)
+      );
+    });
+
+    it("should allow for a successful deletion", () => {
+      cy.mockRequest(
+        {
+          url: "**/api/policies/*",
+          method: "DELETE",
+        },
+        {}
+      );
+      cy.contains("Delete Policy").click();
+
+      cy.contains("Are you sure you want to delete this policy?");
+      cy.contains("Delete Policy").click();
+
+      cy.url().should("match", /\/policies$/);
+      cy.contains("Policy was successfully deleted.").should("be.visible");
+    });
+
+    it("should show an error if the delete failed", () => {
+      cy.mockRequest(
+        {
+          url: "**/api/policies/*",
+          method: "DELETE",
+          status: 500,
+        },
+        {}
+      );
+      cy.contains("Delete Policy").click();
+
+      cy.contains("Are you sure you want to delete this policy?");
+      cy.contains("Delete Policy").click();
+
+      cy.url().should(
+        "match",
+        new RegExp(`/policies/${mockMappedPolicy[0].id}/edit`)
+      );
+      cy.contains(
+        "An error occurred while deleting the policy. Please try again."
+      ).should("be.visible");
     });
   });
 });

--- a/cypress/integration/Policy/policy-playground.spec.js
+++ b/cypress/integration/Policy/policy-playground.spec.js
@@ -88,4 +88,29 @@ context("Policy Playground", () => {
       JSON.stringify(mockFailedPolicyEvaluation.explanation, null, 2)
     ).should("not.exist");
   });
+
+  it("should show an error if the evaluation failed in an unexpected way", () => {
+    cy.mockRequest(
+      { url: "**/api/resources*", method: "GET" },
+      mockMappedResource
+    );
+    cy.mockRequest(
+      { url: "**/api/policies*", method: "GET" },
+      mockMappedPolicy
+    );
+    cy.mockRequest(
+      { url: "**/api/policies/**/attest", method: "POST", status: 500 },
+      mockFailedPolicyEvaluation
+    );
+
+    cy.searchForResource("hello");
+    cy.contains("Select Resource").click();
+    cy.searchForPolicy("policy name");
+    cy.contains("Select Policy").click();
+
+    cy.contains("Evaluate").click();
+    cy.contains("An error occurred while evaluating. Please try again.").should(
+      "be.visible"
+    );
+  });
 });

--- a/cypress/integration/Policy/policy-playground.spec.js
+++ b/cypress/integration/Policy/policy-playground.spec.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockMappedPolicy } from "../../mock-responses/policy-responses";
+import { mockMappedResource } from "../../mock-responses/resource-responses";
+
+context("Policy Playground", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get('[aria-label="Toggle Navigation"]').click();
+    cy.contains("Policy Playground").click();
+    cy.url().should("match", /\/playground/);
+  });
+
+  it("should allow the user to do an evaluation", () => {
+    cy.mockRequest(
+      { url: "**/api/resources*", method: "GET" },
+      mockMappedResource
+    );
+    cy.mockRequest(
+      { url: "**/api/policies*", method: "GET" },
+      mockMappedPolicy
+    );
+
+    cy.searchForResource("hello");
+    cy.contains("Select Resource").click();
+    cy.searchForPolicy("policy name");
+    cy.contains("Select Policy").click();
+
+    cy.contains("Evaluate").click();
+
+    cy.contains(/^the resource (?:passed|failed) the policy./i).should(
+      "be.visible"
+    );
+  });
+});

--- a/cypress/integration/Policy/policy-search.spec.js
+++ b/cypress/integration/Policy/policy-search.spec.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockMappedPolicy } from "../../mock-responses/policy-responses";
+
+context("Policy Search", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get('[aria-label="Toggle Navigation"]').click();
+    cy.get('a[href="/policies"]').click();
+    cy.url().should("match", /\/policies$/);
+  });
+
+  it("should search for a policy that does not exist", () => {
+    cy.mockRequest({ url: "**/api/policies*" }, []);
+
+    cy.searchForPolicy("not a match");
+    cy.contains("No policies found");
+  });
+
+  it("should search for a policy that does exist", () => {
+    cy.mockRequest({ url: "**/api/policies*" }, mockMappedPolicy);
+
+    cy.searchForPolicy("policy");
+    cy.url().should("contain", "search=policy");
+
+    cy.contains("View Policy");
+  });
+
+  it("should show policy details when a policy is selected", () => {
+    const { name, description, regoContent } = mockMappedPolicy[0];
+    cy.mockRequest({ url: "**/api/policies*" }, mockMappedPolicy);
+    cy.mockRequest({ url: "**/api/policies/*" }, mockMappedPolicy[0]);
+
+    cy.searchForPolicy("policy");
+    cy.contains("View Policy").click();
+
+    cy.contains(name).should("be.visible");
+    cy.contains(description).should("be.visible");
+    cy.contains(regoContent).should("be.visible");
+  });
+});

--- a/cypress/integration/resource.spec.js
+++ b/cypress/integration/resource.spec.js
@@ -28,13 +28,13 @@ context("Resources", () => {
   });
 
   it("should search for a resource that does not exist", () => {
-    cy.mockRequest("**/api/resources*", []);
+    cy.mockRequest({ url: "**/api/resources*" }, []);
     cy.searchForResource("not a match");
     cy.contains("No resources found");
   });
 
   it("should search for a resource that does exist", () => {
-    cy.mockRequest("**/api/resources*", mockMappedResource);
+    cy.mockRequest({ url: "**/api/resources*" }, mockMappedResource);
 
     cy.searchForResource("alpine");
     cy.url().should("contain", "search=alpine");
@@ -43,8 +43,8 @@ context("Resources", () => {
   });
 
   it("should show resource details when a resource is selected", () => {
-    cy.mockRequest("**/api/resources*", mockMappedResource);
-    cy.mockRequest("**/api/occurrences*", mockMappedOccurrences);
+    cy.mockRequest({ url: "**/api/resources*" }, mockMappedResource);
+    cy.mockRequest({ url: "**/api/occurrences*" }, mockMappedOccurrences);
 
     cy.searchForResource("nginx");
     cy.contains("View Resource").click();

--- a/cypress/mock-responses/policy-responses.js
+++ b/cypress/mock-responses/policy-responses.js
@@ -32,3 +32,7 @@ export const mockSuccessPolicyValidation = {
   isValid: true,
   errors: null,
 };
+
+export const mockFailedPatchPolicyResponse = {
+  errors: ["Invalid rego code"],
+};

--- a/cypress/mock-responses/policy-responses.js
+++ b/cypress/mock-responses/policy-responses.js
@@ -36,3 +36,14 @@ export const mockSuccessPolicyValidation = {
 export const mockFailedPatchPolicyResponse = {
   errors: ["Invalid rego code"],
 };
+
+export const mockSuccessPolicyEvaluation = {
+  pass: true,
+};
+
+export const mockFailedPolicyEvaluation = {
+  pass: false,
+  explanation: {
+    0: "This is a failed evaluation explanation",
+  },
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,8 +24,8 @@ Cypress.Commands.add("searchForPolicy", (searchTerm) => {
   cy.get('button[aria-label="Search"]').click();
 });
 
-Cypress.Commands.add("mockRequest", (requestToMock, returnValue) => {
+Cypress.Commands.add("mockRequest", ({ url, method = "GET" }, returnValue) => {
   if (!Cypress.env("local_rode_api") === true) {
-    cy.intercept(requestToMock, returnValue);
+    cy.intercept(method, url, returnValue);
   }
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,12 +16,12 @@
 
 Cypress.Commands.add("searchForResource", (searchTerm) => {
   cy.get("#resourceSearch").focus().clear().type(searchTerm);
-  cy.get('button[aria-label="Search"]').click();
+  cy.get('button[aria-label="Search Resources"]').click();
 });
 
 Cypress.Commands.add("searchForPolicy", (searchTerm) => {
   cy.get("#policySearch").focus().clear().type(searchTerm);
-  cy.get('button[aria-label="Search"]').click();
+  cy.get('button[aria-label="Search Policies"]').click();
 });
 
 Cypress.Commands.add(

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,8 +24,14 @@ Cypress.Commands.add("searchForPolicy", (searchTerm) => {
   cy.get('button[aria-label="Search"]').click();
 });
 
-Cypress.Commands.add("mockRequest", ({ url, method = "GET" }, returnValue) => {
-  if (!Cypress.env("local_rode_api") === true) {
-    cy.intercept(method, url, returnValue);
+Cypress.Commands.add(
+  "mockRequest",
+  ({ url, method = "GET", status = 200 }, returnValue) => {
+    if (!Cypress.env("local_rode_api") === true) {
+      cy.intercept(method, url, {
+        statusCode: status,
+        body: returnValue,
+      });
+    }
   }
-});
+);

--- a/test/components/policies/PolicySearchBar.spec.js
+++ b/test/components/policies/PolicySearchBar.spec.js
@@ -76,7 +76,7 @@ describe("PolicySearchBar", () => {
   });
 
   it("should render the button to perform a search", () => {
-    const renderedSearchButton = screen.getByLabelText("Search");
+    const renderedSearchButton = screen.getByLabelText("Search Policies");
     expect(renderedSearchButton).toBeInTheDocument();
     expect(renderedSearchButton).toBeDisabled();
   });
@@ -95,7 +95,7 @@ describe("PolicySearchBar", () => {
 
     rerender(<PolicySearchBar onSubmit={onSubmit} />);
 
-    const renderedSearchButton = screen.getByLabelText("Search");
+    const renderedSearchButton = screen.getByLabelText("Search Policies");
     expect(renderedSearchButton).not.toBeDisabled();
   });
 
@@ -120,7 +120,7 @@ describe("PolicySearchBar", () => {
       dispatch: jest.fn(),
     });
     rerender(<PolicySearchBar onSubmit={onSubmit} />);
-    const renderedSearchButton = screen.getByLabelText("Search");
+    const renderedSearchButton = screen.getByLabelText("Search Policies");
 
     userEvent.click(renderedSearchButton);
 

--- a/test/components/resources/ResourceSearchBar.spec.js
+++ b/test/components/resources/ResourceSearchBar.spec.js
@@ -76,7 +76,7 @@ describe("ResourceSearchBar", () => {
   });
 
   it("should render the button to perform a search", () => {
-    const renderedSearchButton = screen.getByLabelText("Search");
+    const renderedSearchButton = screen.getByLabelText("Search Resources");
     expect(renderedSearchButton).toBeInTheDocument();
     expect(renderedSearchButton).toBeDisabled();
   });
@@ -96,7 +96,7 @@ describe("ResourceSearchBar", () => {
 
     rerender(<ResourceSearchBar onSubmit={onSubmit} />);
 
-    const renderedSearchButton = screen.getByLabelText("Search");
+    const renderedSearchButton = screen.getByLabelText("Search Resources");
     expect(renderedSearchButton).not.toBeDisabled();
   });
 
@@ -121,7 +121,7 @@ describe("ResourceSearchBar", () => {
       dispatch: jest.fn(),
     });
     rerender(<ResourceSearchBar onSubmit={onSubmit} />);
-    const renderedSearchButton = screen.getByLabelText("Search");
+    const renderedSearchButton = screen.getByLabelText("Search Resources");
 
     userEvent.click(renderedSearchButton);
 

--- a/test/components/shared/search/SearchBar.spec.js
+++ b/test/components/shared/search/SearchBar.spec.js
@@ -103,4 +103,20 @@ describe("SearchBar", () => {
 
     expect(screen.getByText(helpText)).toBeInTheDocument();
   });
+
+  it("should allow the user to override the search button label", () => {
+    const buttonLabel = chance.string();
+    rerender(
+      <SearchBar
+        onSubmit={onSubmit}
+        onChange={onChange}
+        label={label}
+        name={name}
+        buttonLabel={buttonLabel}
+      />
+    );
+    const renderedButton = screen.getByLabelText(buttonLabel);
+    expect(renderedButton).toBeInTheDocument();
+    expect(renderedButton.type).toBe("submit");
+  });
 });

--- a/test/testing-utils/mocks.js
+++ b/test/testing-utils/mocks.js
@@ -215,7 +215,9 @@ export const createMockMappedOccurrences = () => {
 };
 
 export const createMockResourceUri = (
-  name = chance.word({ syllables: chance.d20() }),
+  name = `${chance.word({ syllables: chance.d20() })}-${chance.word({
+    syllables: chance.d10(),
+  })}`,
   version = chance.natural()
 ) => {
   return `${name}@sha256:${version}`;


### PR DESCRIPTION
* Adds tests to wrap up policy CRUD
* Adds tests to cover Policy Playground
* Fixes a flaky test issue that arose yesterday where the chance library created two of the same word, which made the tests fail because it was looking for a single instance of the word

I plan on following up with another PR to use [cucumber](https://github.com/TheBrainFamily/cypress-cucumber-preprocessor) because I think it will make reading and contributing to these tests a lot easier than it is today. 