### PR TITLE
Quick UI updates

### DIFF
--- a/components/occurrences/OccurrenceDetails.js
+++ b/components/occurrences/OccurrenceDetails.js
@@ -35,9 +35,12 @@ const OccurrenceDetails = ({ occurrence }) => {
   const DetailComponent = detailComponentMap[occurrence.originals[0].kind];
 
   React.useLayoutEffect(() => {
-    document
-      .getElementById("occurrenceDetails")
-      .scrollIntoView({ behavior: "smooth" });
+    // only scroll to the details if you are on a mobile device
+    if (window.innerWidth < 768) {
+      document
+        .getElementById("occurrenceDetails")
+        .scrollIntoView({ behavior: "smooth" });
+    }
   }, [occurrence]);
 
   return (

--- a/components/occurrences/SecureOccurrenceSection.js
+++ b/components/occurrences/SecureOccurrenceSection.js
@@ -20,6 +20,7 @@ import React from "react";
 import OccurrencePreview from "components/occurrences/OccurrencePreview";
 import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
+import { getVulnerabilityBreakdown } from "utils/occurrence-utils";
 
 const SecureOccurrenceSection = ({ occurrences }) => {
   if (!occurrences?.length) {
@@ -38,7 +39,18 @@ const SecureOccurrenceSection = ({ occurrences }) => {
           currentOccurrence={occurrence}
           mainText={"Vulnerability Scan"}
           timestamp={occurrence.completed}
-          subText={`${occurrence.vulnerabilities.length} vulnerabilities found`}
+          subText={
+            <>
+              <p>{`${occurrence.vulnerabilities.length} vulnerabilities found`}</p>
+              {!!occurrence.vulnerabilities.length && (
+                <p
+                  className={styles.previewBreakdown}
+                >{`${getVulnerabilityBreakdown(
+                  occurrence.vulnerabilities
+                )}`}</p>
+              )}
+            </>
+          }
         />
       ))}
     </div>

--- a/components/occurrences/SecureOccurrenceSection.js
+++ b/components/occurrences/SecureOccurrenceSection.js
@@ -41,13 +41,13 @@ const SecureOccurrenceSection = ({ occurrences }) => {
           timestamp={occurrence.completed}
           subText={
             <>
-              <p>{`${occurrence.vulnerabilities.length} vulnerabilities found`}</p>
+              <span>{`${occurrence.vulnerabilities.length} vulnerabilities found`}</span>
               {!!occurrence.vulnerabilities.length && (
-                <p
+                <span
                   className={styles.previewBreakdown}
                 >{`${getVulnerabilityBreakdown(
                   occurrence.vulnerabilities
-                )}`}</p>
+                )}`}</span>
               )}
             </>
           }

--- a/components/playground/PlaygroundSearchResult.js
+++ b/components/playground/PlaygroundSearchResult.js
@@ -24,6 +24,7 @@ import { ICON_NAMES } from "utils/icon-utils";
 const PlaygroundSearchResult = ({
   mainText,
   subText,
+  additionalText,
   buttonText,
   onClick,
   selected,
@@ -33,6 +34,7 @@ const PlaygroundSearchResult = ({
       <div>
         <p className={styles.cardHeader}>{mainText}</p>
         <p className={styles.cardText}>{subText}</p>
+        {additionalText && <p className={styles.cardText}>{additionalText}</p>}
       </div>
       <Button
         onClick={onClick}
@@ -55,6 +57,7 @@ const PlaygroundSearchResult = ({
 PlaygroundSearchResult.propTypes = {
   mainText: PropTypes.string.isRequired,
   subText: PropTypes.string.isRequired,
+  additionalText: PropTypes.string,
   buttonText: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   selected: PropTypes.bool.isRequired,

--- a/components/playground/ResourceSearchAndResults.js
+++ b/components/playground/ResourceSearchAndResults.js
@@ -59,14 +59,17 @@ const ResourceSearchAndResults = ({
           <Loading loading={resourceLoading} type={"button"}>
             {resourceResults?.length > 0 ? (
               resourceResults.map((result) => {
-                const { resourceName, resourceVersion } = getResourceDetails(
-                  result.uri
-                );
+                const {
+                  resourceName,
+                  resourceVersion,
+                  resourceType,
+                } = getResourceDetails(result.uri);
 
                 return (
                   <PlaygroundSearchResult
                     mainText={resourceName}
                     subText={`Version: ${resourceVersion}`}
+                    additionalText={`Type: ${resourceType}`}
                     buttonText={"Select Resource"}
                     onClick={() => {
                       setResource({

--- a/components/playground/ResourceSearchAndResults.js
+++ b/components/playground/ResourceSearchAndResults.js
@@ -76,6 +76,7 @@ const ResourceSearchAndResults = ({
                         uri: result.uri,
                         name: resourceName,
                         version: resourceVersion,
+                        type: resourceType,
                       });
                       setResourceSearch(false);
                       dispatch({

--- a/components/resources/ResourceOccurrences.js
+++ b/components/resources/ResourceOccurrences.js
@@ -41,14 +41,14 @@ const ResourceOccurrences = (props) => {
       <Loading loading={loading}>
         {data ? (
           <>
-            <div>
+            <div className={styles.occurrencePreviewsContainer}>
               <BuildOccurrenceSection occurrences={data.build} />
               <SecureOccurrenceSection occurrences={data.secure} />
               <DeploymentOccurrenceSection occurrences={data.deploy} />
               <OtherOccurrenceSection occurrences={data.other} />
             </div>
             {state.occurrenceDetails && (
-              <div>
+              <div className={styles.occurrenceDetailsContainer}>
                 <OccurrenceDetails occurrence={state.occurrenceDetails} />
               </div>
             )}

--- a/components/resources/ResourceSearchResult.js
+++ b/components/resources/ResourceSearchResult.js
@@ -22,7 +22,7 @@ import { getResourceDetails } from "utils/resource-utils";
 import SearchResult from "components/shared/search/SearchResult";
 
 const ResourceSearchResult = ({ searchResult }) => {
-  const { resourceName, resourceVersion } = getResourceDetails(
+  const { resourceName, resourceVersion, resourceType } = getResourceDetails(
     searchResult.uri
   );
   const router = useRouter();
@@ -35,6 +35,7 @@ const ResourceSearchResult = ({ searchResult }) => {
     <SearchResult
       mainText={`Resource Name: ${resourceName}`}
       subText={`Version: ${resourceVersion}`}
+      additionalText={`Type: ${resourceType}`}
       actionButton={<Button onClick={onClick} label={"View Resource"} />}
     />
   );

--- a/components/shared/search/SearchResult.js
+++ b/components/shared/search/SearchResult.js
@@ -20,7 +20,7 @@ import styles from "styles/modules/Search.module.scss";
 import { useTheme } from "providers/theme";
 
 const SearchResult = (props) => {
-  const { mainText, subText, actionButton } = props;
+  const { mainText, subText, additionalText, actionButton } = props;
   const { theme } = useTheme();
 
   return (
@@ -28,6 +28,7 @@ const SearchResult = (props) => {
       <div>
         <p className={styles.cardHeader}>{mainText}</p>
         <p className={styles.cardText}>{subText}</p>
+        {additionalText && <p className={styles.cardText}>{additionalText}</p>}
       </div>
       {actionButton}
     </div>
@@ -37,6 +38,7 @@ const SearchResult = (props) => {
 SearchResult.propTypes = {
   mainText: PropTypes.string.isRequired,
   subText: PropTypes.string.isRequired,
+  additionalText: PropTypes.string,
   actionButton: PropTypes.node.isRequired,
 };
 

--- a/pages/api/occurrences.js
+++ b/pages/api/occurrences.js
@@ -32,7 +32,9 @@ export default async (req, res) => {
     const resourceUri = req.query.resourceUri;
     const filter = `"resource.uri"=="${resourceUri}"`;
     const response = await fetch(
-      `${rodeUrl}/v1alpha1/occurrences?filter=${encodeURIComponent(filter)}`
+      `${rodeUrl}/v1alpha1/occurrences?filter=${encodeURIComponent(
+        filter
+      )}&pageSize=1000`
     );
 
     if (!response.ok) {

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -89,8 +89,6 @@ const PolicyPlayground = () => {
     setEvaluationResults(null);
   }, []);
 
-  console.log("state.evaluationResource", state.evaluationResource);
-
   return (
     <div className={`${styles.pageContainer} ${styles[theme]}`}>
       <PageHeader>

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -89,6 +89,8 @@ const PolicyPlayground = () => {
     setEvaluationResults(null);
   }, []);
 
+  console.log("state.evaluationResource", state.evaluationResource);
+
   return (
     <div className={`${styles.pageContainer} ${styles[theme]}`}>
       <PageHeader>
@@ -127,6 +129,12 @@ const PolicyPlayground = () => {
                 <span className={styles.label}>Version</span>
                 <span className={styles.break}>
                   {state.evaluationResource.version}
+                </span>
+              </p>
+              <p className={styles.selectionDetails}>
+                <span className={styles.label}>Type</span>
+                <span className={styles.break}>
+                  {state.evaluationResource.type}
                 </span>
               </p>
               <Button

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -77,7 +77,7 @@ const Resource = () => {
         <div className={styles.resourceHeader}>
           <div>
             <p className={styles.resourceName}>{resourceName}</p>
-            <p>Type: {resourceType}</p>
+            <p className={styles.resourceDetails}>Type: {resourceType}</p>
           </div>
           <div>
             <p className={styles.version}>Version: {resourceVersion}</p>

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -63,6 +63,7 @@ const Resource = () => {
         uri: resourceUri,
         name: resourceName,
         version: resourceVersion,
+        type: resourceType,
       },
     });
     router.push("/playground");

--- a/styles/modules/OccurrenceDetails.module.scss
+++ b/styles/modules/OccurrenceDetails.module.scss
@@ -149,7 +149,7 @@ $SIDE_SPACING: 1rem;
 
   @include tabletAndLarger {
     align-items: flex-end;
-    max-width: 48vw;
+    max-width: 64vw;
   }
 }
 

--- a/styles/modules/Occurrences.module.scss
+++ b/styles/modules/Occurrences.module.scss
@@ -28,10 +28,17 @@ $INDENTATION: 1rem;
   align-items: flex-start;
 
   > div {
-    flex: 1;
     height: 100%;
     width: 100%;
     margin-bottom: 2rem;
+  }
+
+  .occurrencePreviewsContainer {
+    flex: 1;
+  }
+
+  .occurrenceDetailsContainer {
+    flex: 2;
   }
 
   @include tabletAndLarger {

--- a/styles/modules/Occurrences.module.scss
+++ b/styles/modules/Occurrences.module.scss
@@ -118,6 +118,12 @@ $INDENTATION: 1rem;
   @extend .previewSubText;
 }
 
+.previewBreakdown {
+  @extend .previewSubText;
+  line-height: 1rem;
+  margin-left: 0;
+}
+
 .sectionContainer {
   width: 100%;
   margin-top: 1rem;

--- a/styles/modules/Occurrences.module.scss
+++ b/styles/modules/Occurrences.module.scss
@@ -122,6 +122,7 @@ $INDENTATION: 1rem;
   @extend .previewSubText;
   line-height: 1rem;
   margin-left: 0;
+  display: block;
 }
 
 .sectionContainer {

--- a/styles/modules/Resource.module.scss
+++ b/styles/modules/Resource.module.scss
@@ -34,6 +34,8 @@
   justify-content: space-between;
   align-items: flex-start;
   padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
 
   @include tabletAndLarger {
     flex-direction: row;
@@ -42,12 +44,22 @@
 }
 
 .resourceName {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
   @include ellipsis(calc(100vw - 5rem));
 
   @include tabletAndLarger {
+    font-size: 1.5rem;
     max-width: calc(48vw - 2rem);
+  }
+}
+
+.resourceDetails {
+  display: none;
+
+  @include tabletAndLarger {
+    display: unset;
+    max-width: calc(50vw - 5rem);
   }
 }
 

--- a/test/components/occurrences/OccurrenceDetails.spec.js
+++ b/test/components/occurrences/OccurrenceDetails.spec.js
@@ -30,6 +30,36 @@ describe("OccurrenceDetails", () => {
     });
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should scroll to the details when on a mobile device", () => {
+    window.innerWidth = 767;
+    const randomOccurrenceType = chance.pickone(["build", "secure", "deploy"]);
+    render(
+      <OccurrenceDetails
+        occurrence={mappedOccurrences[randomOccurrenceType][0]}
+      />
+    );
+
+    expect(scrollMock)
+      .toHaveBeenCalledTimes(1)
+      .toHaveBeenCalledWith({ behavior: "smooth" });
+  });
+
+  it("should not scroll to the details when on a tablet or larger screened device", () => {
+    window.innerWidth = 768;
+    const randomOccurrenceType = chance.pickone(["build", "secure", "deploy"]);
+    render(
+      <OccurrenceDetails
+        occurrence={mappedOccurrences[randomOccurrenceType][0]}
+      />
+    );
+
+    expect(scrollMock).not.toHaveBeenCalled();
+  });
+
   it("should render the occurrence code block button on any occurrence type", () => {
     const randomOccurrenceType = chance.pickone(["build", "secure", "deploy"]);
     render(
@@ -39,9 +69,6 @@ describe("OccurrenceDetails", () => {
     );
 
     expect(screen.getByText(/show json/i)).toBeInTheDocument();
-    expect(scrollMock)
-      .toHaveBeenCalledTimes(1)
-      .toHaveBeenCalledWith({ behavior: "smooth" });
   });
 
   it("should show the build occurrence details if a build occurrence is selected", () => {

--- a/test/components/occurrences/SecureOccurrenceSection.spec.js
+++ b/test/components/occurrences/SecureOccurrenceSection.spec.js
@@ -18,6 +18,7 @@ import React from "react";
 import { render, screen } from "test/testing-utils/renderer";
 import SecureOccurrenceSection from "components/occurrences/SecureOccurrenceSection";
 import { createMockMappedVulnerabilityOccurrence } from "test/testing-utils/mocks";
+import { getVulnerabilityBreakdown } from "utils/occurrence-utils";
 
 describe("SecureOccurrenceSection", () => {
   let occurrences;
@@ -47,6 +48,15 @@ describe("SecureOccurrenceSection", () => {
         expect(
           screen.queryAllByText("Vulnerability Scan")[index]
         ).toBeInTheDocument();
+
+        if (occurrence.vulnerabilities.length) {
+          const breakdown = getVulnerabilityBreakdown(
+            occurrence.vulnerabilities
+          );
+          const renderedBreakdown = screen.queryAllByText(breakdown);
+
+          expect(renderedBreakdown[0]).toBeInTheDocument();
+        }
 
         const renderedVulnerabilityCount = screen.queryAllByText(
           /vulnerabilities found/i

--- a/test/components/playground/PlaygroundSearchResult.spec.js
+++ b/test/components/playground/PlaygroundSearchResult.spec.js
@@ -65,6 +65,22 @@ describe("PlaygroundSearchResult", () => {
     expect(screen.getByText(subText)).toBeInTheDocument();
   });
 
+  it("should render the additional text if specified", () => {
+    const additionalText = chance.string();
+    rerender(
+      <PlaygroundSearchResult
+        mainText={mainText}
+        subText={subText}
+        additionalText={additionalText}
+        buttonText={buttonText}
+        onClick={onClick}
+        selected={false}
+      />
+    );
+
+    expect(screen.getByText(additionalText)).toBeInTheDocument();
+  });
+
   it("should render the button text when the result is not selected for evaluation", () => {
     rerender(
       <PlaygroundSearchResult

--- a/test/components/playground/ResourceSearchAndResults.spec.js
+++ b/test/components/playground/ResourceSearchAndResults.spec.js
@@ -97,12 +97,17 @@ describe("ResourceSearchAndResults", () => {
 
     expect(screen.queryByTestId("loadingIndicator")).not.toBeInTheDocument();
     resources.forEach((resource) => {
-      const { resourceName, resourceVersion } = getResourceDetails(
-        resource.uri
-      );
+      const {
+        resourceName,
+        resourceVersion,
+        resourceType,
+      } = getResourceDetails(resource.uri);
       expect(screen.getByText(resourceName)).toBeInTheDocument();
       expect(
         screen.getByText(`Version: ${resourceVersion}`)
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByText(`Type: ${resourceType}`)[0]
       ).toBeInTheDocument();
     });
   });

--- a/test/components/playground/ResourceSearchAndResults.spec.js
+++ b/test/components/playground/ResourceSearchAndResults.spec.js
@@ -125,7 +125,7 @@ describe("ResourceSearchAndResults", () => {
 
     searchForResource();
 
-    const { resourceName, resourceVersion } = getResourceDetails(
+    const { resourceName, resourceVersion, resourceType } = getResourceDetails(
       resources[0].uri
     );
 
@@ -134,6 +134,7 @@ describe("ResourceSearchAndResults", () => {
       uri: resources[0].uri,
       name: resourceName,
       version: resourceVersion,
+      type: resourceType,
     });
     expect(dispatch).toHaveBeenCalledWith({
       type: "SET_SEARCH_TERM",
@@ -151,7 +152,7 @@ describe("ResourceSearchAndResults", () => {
 
     fetchResponse.loading = false;
     fetchResponse.data = resources;
-    const { resourceName, resourceVersion } = getResourceDetails(
+    const { resourceName, resourceVersion, resourceType } = getResourceDetails(
       resources[0].uri
     );
 
@@ -163,6 +164,7 @@ describe("ResourceSearchAndResults", () => {
           uri: resources[0].uri,
           name: resourceName,
           version: resourceVersion,
+          type: resourceType,
         }}
       />
     );

--- a/test/components/resources/ResourceSearchResult.spec.js
+++ b/test/components/resources/ResourceSearchResult.spec.js
@@ -24,7 +24,7 @@ import { createMockResourceUri } from "test/testing-utils/mocks";
 jest.mock("next/router");
 
 describe("ResourceSearchResult", () => {
-  let searchResult, resourceName, version, pushMock;
+  let searchResult, resourceName, version, type, pushMock;
 
   beforeEach(() => {
     resourceName = chance.word();
@@ -32,6 +32,7 @@ describe("ResourceSearchResult", () => {
     searchResult = {
       uri: createMockResourceUri(resourceName, version),
     };
+    type = "Docker";
     pushMock = jest.fn();
     useRouter.mockReturnValue({
       push: pushMock,
@@ -44,6 +45,7 @@ describe("ResourceSearchResult", () => {
       screen.getByText(`Resource Name: ${resourceName}`)
     ).toBeInTheDocument();
     expect(screen.getByText(`Version: ${version}`)).toBeInTheDocument();
+    expect(screen.getByText(`Type: ${type}`)).toBeInTheDocument();
   });
 
   it("should render a view resources button ", () => {

--- a/test/components/shared/search/SearchResult.spec.js
+++ b/test/components/shared/search/SearchResult.spec.js
@@ -19,19 +19,20 @@ import { render, screen } from "@testing-library/react";
 import SearchResult from "components/shared/search/SearchResult";
 
 describe("SearchBar", () => {
-  let mainText, subText, actionButtonText;
+  let mainText, subText, actionButtonText, rerender;
 
   beforeEach(() => {
     mainText = chance.sentence();
     subText = chance.sentence();
     actionButtonText = chance.string();
-    render(
+    const utils = render(
       <SearchResult
         mainText={mainText}
         subText={subText}
         actionButton={<button type={"button"}>{actionButtonText}</button>}
       />
     );
+    rerender = utils.rerender;
   });
 
   it("should render the main text", () => {
@@ -48,5 +49,19 @@ describe("SearchBar", () => {
     const renderedButton = screen.getByText(actionButtonText);
     expect(renderedButton).toBeInTheDocument();
     expect(renderedButton.type).toBe("button");
+  });
+
+  it("should render the additional text if specified", () => {
+    const additionalText = chance.string();
+    rerender(
+      <SearchResult
+        mainText={mainText}
+        subText={subText}
+        additionalText={additionalText}
+        actionButton={<button type={"button"}>{actionButtonText}</button>}
+      />
+    );
+    const renderedText = screen.getByText(additionalText);
+    expect(renderedText).toBeInTheDocument();
   });
 });

--- a/test/pages/api/occurrences.spec.js
+++ b/test/pages/api/occurrences.spec.js
@@ -92,7 +92,7 @@ describe("/api/resources", () => {
 
       return `${baseUrl}/v1alpha1/occurrences?filter=${encodeURIComponent(
         expectedFilter
-      )}`;
+      )}&pageSize=1000`;
     };
 
     it("should hit the Rode API", async () => {

--- a/test/pages/playground.spec.js
+++ b/test/pages/playground.spec.js
@@ -115,6 +115,7 @@ describe("PolicyPlayground", () => {
           uri: useFetchResponse.data[0].uri,
           name: resourceName,
           version: resourceVersion,
+          type: "Docker",
         },
       });
     });
@@ -158,6 +159,7 @@ describe("PolicyPlayground", () => {
         uri: chance.string(),
         name: chance.string(),
         version: chance.string(),
+        type: chance.string(),
       };
       selectedPolicy = {
         name: chance.string(),
@@ -175,6 +177,7 @@ describe("PolicyPlayground", () => {
     it("should render the selected resource details", () => {
       expect(screen.getByText(selectedResource.name)).toBeInTheDocument();
       expect(screen.getByText(selectedResource.version)).toBeInTheDocument();
+      expect(screen.getByText(selectedResource.type)).toBeInTheDocument();
 
       const renderedClearResourceButton = screen.getByRole("button", {
         name: "Clear Resource",

--- a/test/pages/resources/[resourceUri].spec.js
+++ b/test/pages/resources/[resourceUri].spec.js
@@ -67,7 +67,7 @@ describe("Resource Details page", () => {
   });
 
   it("should render a button to use the resource in the policy playground", () => {
-    const { resourceName, resourceVersion } = getResourceDetails(
+    const { resourceName, resourceVersion, resourceType } = getResourceDetails(
       router.query.resourceUri
     );
 
@@ -86,6 +86,7 @@ describe("Resource Details page", () => {
           uri: router.query.resourceUri,
           name: resourceName,
           version: resourceVersion,
+          type: resourceType,
         },
       });
 

--- a/test/utils/occurrence-utils.spec.js
+++ b/test/utils/occurrence-utils.spec.js
@@ -20,6 +20,16 @@ describe("occurrence-utils", () => {
   describe("getVulnerabilityBreakdown", () => {
     let vulnerabilities;
 
+    it("should return the correct count for any critical severity vulnerabilities", () => {
+      vulnerabilities = chance.n(
+        () => ({ effectiveSeverity: "CRITICAL" }),
+        chance.d4()
+      );
+      const actual = getVulnerabilityBreakdown(vulnerabilities);
+
+      expect(actual).toBe(`${vulnerabilities.length} critical`);
+    });
+
     it("should return the correct count for any high severity vulnerabilities", () => {
       vulnerabilities = chance.n(
         () => ({ effectiveSeverity: "HIGH" }),

--- a/utils/occurrence-utils.js
+++ b/utils/occurrence-utils.js
@@ -18,6 +18,7 @@ export const getVulnerabilityBreakdown = (vulnerabilities) => {
   let low = 0;
   let medium = 0;
   let high = 0;
+  let critical = 0;
   let unknown = 0;
 
   vulnerabilities.forEach((vuln) => {
@@ -27,12 +28,15 @@ export const getVulnerabilityBreakdown = (vulnerabilities) => {
       medium++;
     } else if (vuln.effectiveSeverity === "HIGH") {
       high++;
+    } else if (vuln.effectiveSeverity === "CRITICAL") {
+      critical++;
     } else {
       unknown++;
     }
   });
 
   const values = [
+    critical && `${critical} critical`,
     high && `${high} high`,
     medium && `${medium} medium`,
     low && `${low} low`,


### PR DESCRIPTION
Included in this PR

* Showing resource type in search results and policy playground
* Occurrence details takes up 2/3 of the screen, while the preview cards that you click take up 1/3 when you are viewing details of an occurrence
* Sticky Resource details header when viewing Resource details
* Add Critical severity to the breakdown list
* Show vulnerability breakdown on the occurrence preview of a vulnerability scan with vulnerabilities
* Adds large page size to the call to fetch occurrences so vulnerability scans will work as expected 
   * Note: pagination is _not_ fully implemented yet in the UI, but this should be okay until pagination is fully worked out in grafeas-elasticsearch
---
_Coming in a follow-up PR_
* Download or copy JSON button
* Move the Show JSON button to the top of the details screen
* Collapsable descriptions of vulnerabilities
cc @RobertKelly 