### PR TITLE
Automatically generate a changelog release on tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,6 @@ jobs:
       - run: |
           yarn
           yarn verify
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -41,3 +40,16 @@ jobs:
           tags: |
             ghcr.io/rode/ui:latest
             ghcr.io/rode/ui:${{ steps.gitextra.outputs.version }}
+
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{steps.github_release.outputs.changelog}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automagically compile a changelog history and create a github
release after a tag is published and an artifact is created.

#52 