### PR TITLE
Consume ListVersionedResourceOccurrences instead of ListOccurrences

### DIFF
--- a/pages/api/occurrences.js
+++ b/pages/api/occurrences.js
@@ -30,10 +30,9 @@ export default async (req, res) => {
 
   try {
     const resourceUri = req.query.resourceUri;
-    const filter = `"resource.uri"=="${resourceUri}"`;
     const response = await fetch(
-      `${rodeUrl}/v1alpha1/occurrences?filter=${encodeURIComponent(
-        filter
+      `${rodeUrl}/v1alpha1/versioned-resource-occurrences?resourceUri=${encodeURIComponent(
+        resourceUri
       )}&pageSize=1000`
     );
 

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -35,7 +35,7 @@ export default async (req, res) => {
       let filter = {};
       if (searchTerm) {
         filter = {
-          filter: `"policy.name".contains("${searchTerm}")`,
+          filter: `policy.name.contains("${searchTerm}")`,
         };
       }
       const response = await fetch(

--- a/pages/api/resources.js
+++ b/pages/api/resources.js
@@ -32,7 +32,7 @@ export default async (req, res) => {
     let filter = {};
     if (searchTerm) {
       filter = {
-        filter: `"resource.uri".contains("${searchTerm}")`,
+        filter: `resource.uri.contains("${searchTerm}")`,
       };
     }
     const response = await fetch(

--- a/test/pages/api/occurrences.spec.js
+++ b/test/pages/api/occurrences.spec.js
@@ -88,10 +88,8 @@ describe("/api/resources", () => {
     });
 
     const createExpectedUrl = (baseUrl) => {
-      const expectedFilter = `"resource.uri"=="${resourceUriParam}"`;
-
-      return `${baseUrl}/v1alpha1/occurrences?filter=${encodeURIComponent(
-        expectedFilter
+      return `${baseUrl}/v1alpha1/versioned-resource-occurrences?resourceUri=${encodeURIComponent(
+        resourceUriParam
       )}&pageSize=1000`;
     };
 

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -108,7 +108,7 @@ describe("/api/policies", () => {
 
       it("should hit the Rode API", async () => {
         const expectedUrl = createExpectedUrl("http://localhost:50051", {
-          filter: `"policy.name".contains("${filterParam}")`,
+          filter: `policy.name.contains("${filterParam}")`,
         });
 
         await handler(request, response);

--- a/test/pages/api/resources.spec.js
+++ b/test/pages/api/resources.spec.js
@@ -94,7 +94,7 @@ describe("/api/resources", () => {
 
     it("should hit the Rode API", async () => {
       const expectedUrl = createExpectedUrl("http://localhost:50051", {
-        filter: `"resource.uri".contains("${filterParam}")`,
+        filter: `resource.uri.contains("${filterParam}")`,
       });
 
       await handler(request, response);
@@ -114,7 +114,7 @@ describe("/api/resources", () => {
     it("should take the Rode URL from the environment if set", async () => {
       const rodeUrl = chance.url();
       const expectedUrl = createExpectedUrl(rodeUrl, {
-        filter: `"resource.uri".contains("${filterParam}")`,
+        filter: `resource.uri.contains("${filterParam}")`,
       });
       process.env.RODE_URL = rodeUrl;
 


### PR DESCRIPTION
This changes the `/api/occurrences` endpoint to consume the `ListVersionedResourceOccurrences` endpoint, which takes a `resourceUri` instead of a filter.

It tries to match up related occurrences, which means that Git and artifact occurrence overviews should look the same now if there's a build occurrence linking them. 

docker image:
![Screen Shot 2021-04-28 at 4 04 10 PM](https://user-images.githubusercontent.com/9082799/116473327-ab471a80-a83c-11eb-9832-c64577d69c31.png)

related Git commit:
![Screen Shot 2021-04-28 at 4 04 25 PM](https://user-images.githubusercontent.com/9082799/116473329-abdfb100-a83c-11eb-95fb-f513eb027a8a.png)

I also made a small change to remove the quotes around any field names. The `filtering` package in `grafeas-elasticsearch` should handle those now (although quoting the fields still works). 