### PR TITLE
Populate release changelog

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,10 +46,16 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v1.7.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          configuration: release.json
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          body: ${{steps.github_release.outputs.changelog}}
+          body: |
+            ${{steps.github_release.outputs.changelog}}
+            ## Docker images
+            ghcr.io/rode/ui:latest
+            ghcr.io/rode/ui:${{ steps.gitextra.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
           body: |
             ${{steps.github_release.outputs.changelog}}
             ## Docker images
-            ghcr.io/rode/ui:latest
-            ghcr.io/rode/ui:${{ steps.gitextra.outputs.version }}
+            - `ghcr.io/rode/ui:latest`
+            - `ghcr.io/rode/ui:${{ steps.gitextra.outputs.version }}`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release.json
+++ b/release.json
@@ -1,0 +1,5 @@
+{
+  "categories": [],
+  "template": "## Changelog\n${{UNCATEGORIZED}}",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})"
+}


### PR DESCRIPTION
Closes #71 

Adds config to populate the changelog. All of our PRs were getting classified as uncategorized, which doesn't seem to be rendered in the [default configuration](https://github.com/mikepenz/release-changelog-builder-action/blob/088993b64ceb224f5c7824ab510e8edb623aa875/src/configuration.ts#L41) (in the template `{{CHANGELOG}}` is the content of all categorized changes). 

<details>
<summary>Sample output</summary>

## Changelog

- Consume ListVersionedResourceOccurrences instead of ListOccurrences (#68)
- Syntax Highlighting, Example Hello World policy (#67)
- Pagination (#63)
- pin version of release-changelog-builder-action (#70)

## Docker images

ghcr.io/rode/ui:latest 
ghcr.io/rode/ui:v0.6.0-18-ge35e7aa

</details>