### PR TITLE
Safe effects

### DIFF
--- a/components/ExternalLink.js
+++ b/components/ExternalLink.js
@@ -23,10 +23,10 @@ import { useTheme } from "providers/theme";
 
 const ExternalLink = (props) => {
   const { theme } = useTheme();
-  const { href, label, className = "" } = props;
+  const { href, label, className = "", fallback = null } = props;
 
   if (!href) {
-    return null;
+    return fallback;
   }
 
   return (
@@ -46,6 +46,7 @@ ExternalLink.propTypes = {
   href: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   className: PropTypes.string,
+  fallback: PropTypes.node,
 };
 
 export default ExternalLink;

--- a/components/Modal.js
+++ b/components/Modal.js
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-import React, { useLayoutEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Modal.module.scss";
 import { useTheme } from "providers/theme";
 import Button from "./Button";
 import Icon from "./Icon";
 import { ICON_NAMES } from "utils/icon-utils";
+import { useSafeLayoutEffect } from "hooks/useSafeLayoutEffect";
 
 const Modal = (props) => {
   const { title, children, onClose, isVisible } = props;
   const { theme } = useTheme();
 
-  useLayoutEffect(() => {
+  useSafeLayoutEffect(() => {
     if (isVisible) {
       document.getElementById("modalWrapper").scrollIntoView();
     }

--- a/components/occurrences/BuildOccurrenceDetails.js
+++ b/components/occurrences/BuildOccurrenceDetails.js
@@ -28,20 +28,17 @@ const BuildOccurrenceDetails = ({ occurrence }) => {
       <div className={styles.detailSummary}>
         <div>
           <p className={styles.title}>Build</p>
-          {occurrence.sourceUri ? (
-            <ExternalLink
-              href={occurrence.sourceUri}
-              label={"View source"}
-              className={styles.rightMargin}
-            />
-          ) : (
-            <p className={styles.subtext}>Source not available</p>
-          )}
-          {occurrence.logsUri ? (
-            <ExternalLink href={occurrence.logsUri} label={"View logs"} />
-          ) : (
-            <p className={styles.subtext}>Logs not available</p>
-          )}
+          <ExternalLink
+            href={occurrence.sourceUri}
+            label={"View source"}
+            className={styles.rightMargin}
+            fallback={<p className={styles.subtext}>Source not available</p>}
+          />
+          <ExternalLink
+            href={occurrence.logsUri}
+            label={"View logs"}
+            fallback={<p className={styles.subtext}>Logs not available</p>}
+          />
           <p>Created by {occurrence.creator}</p>
         </div>
         <div className={styles.rightDetails}>

--- a/components/occurrences/BuildOccurrenceDetails.js
+++ b/components/occurrences/BuildOccurrenceDetails.js
@@ -28,12 +28,20 @@ const BuildOccurrenceDetails = ({ occurrence }) => {
       <div className={styles.detailSummary}>
         <div>
           <p className={styles.title}>Build</p>
-          <ExternalLink
-            href={occurrence.sourceUri}
-            label={"View source"}
-            className={styles.rightMargin}
-          />
-          <ExternalLink href={occurrence.logsUri} label={"View logs"} />
+          {occurrence.sourceUri ? (
+            <ExternalLink
+              href={occurrence.sourceUri}
+              label={"View source"}
+              className={styles.rightMargin}
+            />
+          ) : (
+            <p className={styles.subtext}>Source not available</p>
+          )}
+          {occurrence.logsUri ? (
+            <ExternalLink href={occurrence.logsUri} label={"View logs"} />
+          ) : (
+            <p className={styles.subtext}>Logs not available</p>
+          )}
           <p>Created by {occurrence.creator}</p>
         </div>
         <div className={styles.rightDetails}>

--- a/components/occurrences/OccurrenceDetails.js
+++ b/components/occurrences/OccurrenceDetails.js
@@ -21,6 +21,7 @@ import BuildOccurrenceDetails from "./BuildOccurrenceDetails";
 import VulnerabilityOccurrenceDetails from "./VulnerabilityOccurrenceDetails";
 import DeploymentOccurrenceDetails from "./DeploymentOccurrenceDetails";
 import { useTheme } from "providers/theme";
+import { useSafeLayoutEffect } from "hooks/useSafeLayoutEffect";
 
 const detailComponentMap = {
   BUILD: BuildOccurrenceDetails,
@@ -34,7 +35,7 @@ const OccurrenceDetails = ({ occurrence }) => {
   const DetailComponent =
     detailComponentMap[occurrence.originals.occurrences[0].kind];
 
-  React.useLayoutEffect(() => {
+  useSafeLayoutEffect(() => {
     // only scroll to the details if you are on a mobile device
     if (window.innerWidth < 768) {
       document

--- a/hooks/usePolicy.js
+++ b/hooks/usePolicy.js
@@ -18,7 +18,7 @@ import React from "react";
 import { useFetch } from "./useFetch";
 import { usePolicies } from "providers/policies";
 import { policyActions } from "reducers/policies";
-import { isServerSide } from "utils/shared-utils";
+import { useSafeLayoutEffect } from "./useSafeLayoutEffect";
 
 export const usePolicy = (policyId) => {
   const [policy, setPolicy] = React.useState(null);
@@ -31,9 +31,7 @@ export const usePolicy = (policyId) => {
     policyId !== currentPolicy?.id ? `/api/policies/${policyId}` : null
   );
 
-  const useEffect = isServerSide() ? React.useEffect : React.useLayoutEffect;
-
-  useEffect(() => {
+  useSafeLayoutEffect(() => {
     if (policyId === currentPolicy?.id) {
       setPolicy(currentPolicy);
     } else if (data) {

--- a/hooks/useSafeLayoutEffect.js
+++ b/hooks/useSafeLayoutEffect.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useLayoutEffect, useEffect } from "react";
+import { isServerSide } from "utils/shared-utils";
+
+export const useSafeLayoutEffect = (logic, deps) => {
+  const useSafeEffect = isServerSide() ? useEffect : useLayoutEffect;
+
+  useSafeEffect(logic, deps);
+};

--- a/pages/api/utils/occurrence-utils.js
+++ b/pages/api/utils/occurrence-utils.js
@@ -157,9 +157,7 @@ const mapBuilds = (occurrences) => {
       completed: occ.build.provenance.endTime,
       creator: occ.build.provenance.creator,
       artifacts: occ.build.provenance.builtArtifacts,
-      sourceUri: occ.build.provenance.sourceProvenance.context.git.url
-        ? `${occ.build.provenance.sourceProvenance.context.git.url}/tree/${occ.build.provenance.sourceProvenance.context.git.revisionId}`
-        : null,
+      sourceUri: occ.build.provenance.sourceProvenance.context.git.url,
       logsUri: occ.build.provenance.logsUri,
       originals: { occurrences: [occ] },
     };

--- a/providers/theme.js
+++ b/providers/theme.js
@@ -18,6 +18,7 @@ import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { LIGHT_THEME, DARK_THEME } from "utils/theme-utils";
 import { isServerSide } from "utils/shared-utils";
+import { useSafeLayoutEffect } from "hooks/useSafeLayoutEffect";
 const LOCAL_STORAGE_THEME_KEY = "rode-ui-theme";
 
 const ThemeContext = React.createContext({
@@ -40,10 +41,9 @@ const getInitialTheme = () => {
 };
 
 export const ThemeProvider = (props) => {
-  const useEffect = isServerSide() ? React.useEffect : React.useLayoutEffect;
   const [theme, setTheme] = React.useState(LIGHT_THEME);
 
-  useEffect(() => {
+  useSafeLayoutEffect(() => {
     const savedTheme = localStorage.getItem(LOCAL_STORAGE_THEME_KEY);
 
     if (savedTheme) {

--- a/styles/constants.scss
+++ b/styles/constants.scss
@@ -32,9 +32,7 @@ $SOFT_WHITE: #f8f8f8;
 $WHITE: #ffffff;
 
 // shadows
-$FOCUS_SHADOW: 0 0 0 3px rgba(0, 193, 219, 0.35);
-$HOVER_SHADOW: 0px 10px 15px -3px rgba(0, 0, 0, 0.1),
-  2px 4px 6px -2px rgba(0, 0, 0, 0.05);
+$FOCUS_SHADOW: 0 0 0 3px rgba(0, 193, 219, 0.45);
 
 // breakpoints
 $SCREEN_PHONE: 640px;
@@ -43,7 +41,7 @@ $SCREEN_DESKTOP: 1024px;
 
 // DARK theme
 $DT_BOX_SHADOW: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-$DT_HOVER_SHADOW: 0px 10px 15px -3px rgba(0, 0, 0, 0.3),
+$DT_HOVER_SHADOW: 0px 10px 15px -3px rgba(0, 0, 0, 0.4),
   2px 4px 6px -2px rgba(0, 0, 0, 0.15);
 $DT_BACKGROUND_DARK: $DARKEST_GREY;
 $DT_BACKGROUND_MEDIUM: $DARK_GREY;
@@ -56,7 +54,7 @@ $DT_HOVER_GREEN: #23ae20;
 // LIGHT theme
 $LT_BOX_SHADOW: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
 $LT_HOVER_SHADOW: 0px 10px 15px -3px rgba(0, 0, 0, 0.1),
-  2px 4px 6px -2px rgba(50, 50, 50, 0.05);
+  2px 4px 6px -2px rgba(50, 50, 50, 0.15);
 $LT_BACKGROUND_DARK: $WHITE_SMOKE;
 $LT_BACKGROUND_MEDIUM: $SOFT_WHITE;
 $LT_BACKGROUND_LIGHT: $WHITE;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -60,14 +60,18 @@ body {
 a {
   text-decoration: none;
 
-  &:hover {
+  &:hover,
+  &:focus {
     text-decoration: underline;
   }
 
   &:focus,
   &:active {
-    box-shadow: $FOCUS_SHADOW;
     outline: none;
+  }
+
+  &:active {
+    box-shadow: $FOCUS_SHADOW;
   }
 }
 

--- a/styles/modules/Header.module.scss
+++ b/styles/modules/Header.module.scss
@@ -49,6 +49,8 @@ $DESKTOP_NAV_WIDTH: 30vw;
   max-width: 4rem;
   min-width: 3rem;
   display: inline-block;
+  border-bottom: solid 3px transparent;
+  @include transition;
 }
 
 .expandedNavigation {
@@ -174,6 +176,14 @@ $DESKTOP_NAV_WIDTH: 30vw;
       color: $DT_MAIN_TEXT;
     }
   }
+
+  .logo {
+    &:focus,
+    &:hover {
+      @include transition;
+      border-bottom-color: $DT_LINK;
+    }
+  }
 }
 
 .lightTheme {
@@ -191,6 +201,14 @@ $DESKTOP_NAV_WIDTH: 30vw;
 
     &:visited {
       color: $LT_MAIN_TEXT;
+    }
+  }
+
+  .logo {
+    &:focus,
+    &:hover {
+      @include transition;
+      border-bottom-color: $LT_LINK;
     }
   }
 }

--- a/styles/modules/Inputs.module.scss
+++ b/styles/modules/Inputs.module.scss
@@ -30,10 +30,6 @@ $PADDING: 0.5rem;
   flex-direction: column;
   height: fit-content;
   width: 100%;
-
-  //&:focus-within {
-  //  box-shadow: $FOCUS_SHADOW;
-  //}
 }
 
 .horizontalContainer {

--- a/styles/modules/Inputs.module.scss
+++ b/styles/modules/Inputs.module.scss
@@ -31,9 +31,9 @@ $PADDING: 0.5rem;
   height: fit-content;
   width: 100%;
 
-  &:focus-within {
-    box-shadow: $FOCUS_SHADOW;
-  }
+  //&:focus-within {
+  //  box-shadow: $FOCUS_SHADOW;
+  //}
 }
 
 .horizontalContainer {
@@ -59,6 +59,10 @@ $PADDING: 0.5rem;
   &:focus {
     outline: none;
     border-bottom: solid 1px $LAGOON;
+  }
+
+  &:active {
+    box-shadow: $FOCUS_SHADOW;
   }
 
   &[disabled] {

--- a/styles/modules/OccurrenceDetails.module.scss
+++ b/styles/modules/OccurrenceDetails.module.scss
@@ -66,6 +66,14 @@ $SIDE_SPACING: 1rem;
   }
 }
 
+.subtext {
+  margin-right: 1rem;
+
+  @include desktopAndLarger {
+    display: inline;
+  }
+}
+
 .timestamps {
   text-align: left;
 
@@ -180,7 +188,8 @@ $SIDE_SPACING: 1rem;
     background-color: $DT_BACKGROUND_DARK;
   }
 
-  .timestamps {
+  .timestamps,
+  .subtext {
     color: $DT_SUB_TEXT;
   }
 
@@ -217,7 +226,8 @@ $SIDE_SPACING: 1rem;
     background-color: $LT_BACKGROUND_DARK;
   }
 
-  .timestamps {
+  .timestamps,
+  .subtext {
     color: $LT_SUB_TEXT;
   }
 

--- a/test/components/ExternalLink.spec.js
+++ b/test/components/ExternalLink.spec.js
@@ -27,8 +27,21 @@ describe("ExternalLink", () => {
     rerender = utils.rerender;
   });
 
-  it("should return null when no href is present", () => {
+  it("should return null when no href is present and no fallback component is specified", () => {
     expect(screen.queryByText(label)).not.toBeInTheDocument();
+  });
+
+  it("should return the fallback component when no href is present", () => {
+    const fallbackText = chance.string();
+    rerender(
+      <ExternalLink
+        href={null}
+        label={label}
+        fallback={<p>{fallbackText}</p>}
+      />
+    );
+
+    expect(screen.getByText(fallbackText)).toBeInTheDocument();
   });
 
   describe("link exists and should show", () => {

--- a/test/components/occurrences/BuildOccurrenceDetails.spec.js
+++ b/test/components/occurrences/BuildOccurrenceDetails.spec.js
@@ -23,7 +23,7 @@ import dayjs from "dayjs";
 jest.mock("dayjs");
 
 describe("BuildOccurrenceDetails", () => {
-  let occurrence;
+  let occurrence, rerender;
 
   beforeEach(() => {
     occurrence = createMockMappedBuildOccurrence();
@@ -34,7 +34,8 @@ describe("BuildOccurrenceDetails", () => {
         .mockReturnValue(occurrence.completed),
     });
 
-    render(<BuildOccurrenceDetails occurrence={occurrence} />);
+    const utils = render(<BuildOccurrenceDetails occurrence={occurrence} />);
+    rerender = utils.rerender;
   });
 
   afterEach(() => {
@@ -58,6 +59,20 @@ describe("BuildOccurrenceDetails", () => {
     expect(
       screen.getByRole("button", { name: "Show JSON" })
     ).toBeInTheDocument();
+  });
+
+  it("should show source not available if there are is not a source uri", () => {
+    occurrence.sourceUri = null;
+    rerender(<BuildOccurrenceDetails occurrence={occurrence} />);
+
+    expect(screen.getByText("Source not available")).toBeInTheDocument();
+  });
+
+  it("should show logs not available if there are is not logs uri", () => {
+    occurrence.logsUri = null;
+    rerender(<BuildOccurrenceDetails occurrence={occurrence} />);
+
+    expect(screen.getByText("Logs not available")).toBeInTheDocument();
   });
 
   it("should show the list of artifacts produced from the build", () => {

--- a/test/components/resources/ResourceSearchResult.spec.js
+++ b/test/components/resources/ResourceSearchResult.spec.js
@@ -27,8 +27,8 @@ describe("ResourceSearchResult", () => {
   let searchResult, resourceName, version, type, pushMock;
 
   beforeEach(() => {
-    resourceName = chance.word();
-    version = chance.word();
+    resourceName = chance.string();
+    version = chance.string({ min: 12 });
     searchResult = {
       uri: createMockResourceUri(resourceName, version),
     };

--- a/test/hooks/useSafeLayoutEffect.spec.js
+++ b/test/hooks/useSafeLayoutEffect.spec.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render } from "test/testing-utils/renderer";
+import { useFetch } from "hooks/useFetch";
+import { isServerSide } from "utils/shared-utils";
+import ComponentUsingSafeLayout from "test/testing-utils/hook-components/usePolicyComponent";
+
+jest.mock("hooks/useFetch");
+jest.mock("utils/shared-utils");
+
+describe("useSafeLayoutEffect", () => {
+  let policy, fetchResponse;
+
+  beforeEach(() => {
+    policy = {
+      name: chance.string(),
+      description: chance.string(),
+      regoContent: chance.string(),
+      id: chance.guid(),
+    };
+
+    fetchResponse = {
+      data: policy,
+      loading: false,
+    };
+
+    jest.spyOn(React, "useEffect");
+    jest.spyOn(React, "useLayoutEffect");
+
+    useFetch.mockReturnValue(fetchResponse);
+    isServerSide.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should use the correct effect hook when on the server", () => {
+    isServerSide.mockReturnValue(true);
+    render(<ComponentUsingSafeLayout id={policy.id} />);
+
+    expect(React.useEffect).toHaveBeenCalled();
+  });
+
+  it("should use the correct effect hook when on the client", () => {
+    isServerSide.mockReturnValue(false);
+    render(<ComponentUsingSafeLayout id={policy.id} />);
+
+    expect(React.useLayoutEffect).toHaveBeenCalled();
+  });
+});

--- a/test/hooks/useSafeLayoutEffect.spec.js
+++ b/test/hooks/useSafeLayoutEffect.spec.js
@@ -28,9 +28,6 @@ describe("useSafeLayoutEffect", () => {
 
   beforeEach(() => {
     policy = {
-      name: chance.string(),
-      description: chance.string(),
-      regoContent: chance.string(),
       id: chance.guid(),
     };
 

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -193,20 +193,12 @@ describe("occurrence-utils", () => {
           buildOccurrence.build.provenance.builtArtifacts
         );
         expect(build[0].sourceUri).toEqual(
-          `${buildOccurrence.build.provenance.sourceProvenance.context.git.url}/tree/${buildOccurrence.build.provenance.sourceProvenance.context.git.revisionId}`
+          buildOccurrence.build.provenance.sourceProvenance.context.git.url
         );
         expect(build[0].logsUri).toEqual(
           buildOccurrence.build.provenance.logsUri
         );
         expect(build[0].originals.occurrences).toContain(buildOccurrence);
-      });
-
-      it("should correctly map builds without source urls", () => {
-        const buildOccurrence = createMockOccurrence("BUILD");
-        buildOccurrence.build.provenance.sourceProvenance.context.git.url = null;
-        const { build } = mapOccurrencesToSections([buildOccurrence]);
-
-        expect(build[0].sourceUri).toBeNull();
       });
     });
 

--- a/test/providers/theme.spec.js
+++ b/test/providers/theme.spec.js
@@ -23,7 +23,7 @@ import { isServerSide } from "utils/shared-utils";
 jest.mock("utils/shared-utils");
 
 describe("theme provider", () => {
-  let rerender, originalLocalStorage, getItemMock, setItemMock;
+  let originalLocalStorage, getItemMock, setItemMock;
 
   beforeEach(() => {
     originalLocalStorage = window.localStorage;
@@ -41,9 +41,7 @@ describe("theme provider", () => {
     jest.spyOn(React, "useLayoutEffect");
 
     act(() => {
-      const utils = render(<ThemeComponent />);
-
-      rerender = utils.rerender;
+      render(<ThemeComponent />);
     });
   });
 
@@ -67,14 +65,5 @@ describe("theme provider", () => {
     userEvent.click(toggleButton);
     expect(screen.getByText(/light/i)).toBeInTheDocument();
     expect(setItemMock).toHaveBeenCalledWith("rode-ui-theme", "lightTheme");
-  });
-
-  it("should use the correct effect hook when on the server", () => {
-    expect(React.useLayoutEffect).toHaveBeenCalled();
-
-    isServerSide.mockReturnValue(true);
-    rerender(<ThemeComponent />);
-
-    expect(React.useEffect).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
* Adds `useSafeLayoutEffect` hook that checks for server side rendering before using a client-only effect
* Shows "Source not available" or "Logs not available" when the field is not populated in a build occurrence
* Uses `git.uri` of the build occurrence to populate the source url
* Some styling updates for better accessibility/less box shadowing when focusing on inputs