### PR TITLE
Show occurrence data in policy playground

### DIFF
--- a/components/playground/SelectedPolicy.js
+++ b/components/playground/SelectedPolicy.js
@@ -56,7 +56,11 @@ const SelectedPolicy = (props) => {
           <p className={styles.selectionDetails}>
             <span className={typeStyles.label}>Rego Policy Code</span>
           </p>
-          <Code code={policy.regoContent} language={"rego"} />
+          <Code
+            code={policy.regoContent}
+            language={"rego"}
+            className={styles.codeContent}
+          />
         </div>
       )}
     </div>

--- a/components/playground/SelectedResource.js
+++ b/components/playground/SelectedResource.js
@@ -20,12 +20,21 @@ import Button from "components/Button";
 import styles from "styles/modules/Playground.module.scss";
 import ResourceVersion from "components/resources/ResourceVersion";
 import LabelWithValue from "components/LabelWithValue";
+import Code from "components/Code";
+import { useFetch } from "hooks/useFetch";
+import typeStyles from "styles/modules/Typography.module.scss";
+import Loading from "components/Loading";
 
 const SelectedResource = (props) => {
   const { resource, clearResource } = props;
 
   const [showDetails, setShowDetails] = useState(false);
   const toggleDetails = () => setShowDetails(!showDetails);
+
+  const { data, loading } = useFetch(`/api/occurrences`, {
+    resourceUri: resource.uri,
+  });
+
   return (
     <div className={styles.selectionContainer}>
       <h2 className={styles.selectionTitle}>
@@ -64,6 +73,16 @@ const SelectedResource = (props) => {
             value={resource.type}
             className={styles.selectionDetails}
           />
+          <Loading loading={loading}>
+            <p className={styles.selectionDetails}>
+              <span className={typeStyles.label}>Occurrence Data</span>
+            </p>
+            <Code
+              code={JSON.stringify(data?.originals, null, 2)}
+              language={"json"}
+              className={styles.codeContent}
+            />
+          </Loading>
         </div>
       )}
     </div>

--- a/cypress/integration/Resource/resource.js
+++ b/cypress/integration/Resource/resource.js
@@ -94,6 +94,10 @@ Then(/^I see "([^"]*)" resource search result$/, (resourceName) => {
 
 Then(/^I see "([^"]*)" resource details$/, (resourceName) => {
   const resource = resources[resourceName].data[0];
+  cy.mockRequest(
+    {url: "**/api/occurrences*", method: "GET"},
+    resource.occurrences
+  );
 
   cy.url().should("contain", `/resources/${encodeURIComponent(resource.uri)}`);
   cy.contains(resource.resourceName).should("be.visible");

--- a/cypress/integration/Resource/resource.js
+++ b/cypress/integration/Resource/resource.js
@@ -95,7 +95,7 @@ Then(/^I see "([^"]*)" resource search result$/, (resourceName) => {
 Then(/^I see "([^"]*)" resource details$/, (resourceName) => {
   const resource = resources[resourceName].data[0];
   cy.mockRequest(
-    {url: "**/api/occurrences*", method: "GET"},
+    { url: "**/api/occurrences*", method: "GET" },
     resource.occurrences
   );
 

--- a/pages/api/utils/occurrence-utils.js
+++ b/pages/api/utils/occurrence-utils.js
@@ -229,5 +229,6 @@ export const mapOccurrencesToSections = (occurrences, resourceUri) => {
     secure: vulnerabilities,
     deploy: mapDeployments(deploymentOccurrences),
     other: [...other, ...otherOccurrences],
+    originals: { occurrences },
   };
 };

--- a/styles/modules/Playground.module.scss
+++ b/styles/modules/Playground.module.scss
@@ -162,6 +162,12 @@ $CARD_WIDTH: 97%;
   }
 }
 
+.codeContent {
+  height: 35vh;
+  resize: vertical;
+  overflow: auto;
+}
+
 .pageTitle {
   font-size: 1.25rem;
   font-weight: 600;

--- a/test/components/playground/SelectedResource.spec.js
+++ b/test/components/playground/SelectedResource.spec.js
@@ -18,22 +18,37 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SelectedResource from "components/playground/SelectedResource";
+import { useFetch } from "hooks/useFetch";
+
+jest.mock("hooks/useFetch");
 
 describe("SelectedResource", () => {
-  let resource, clearResource;
+  let resource, clearResource, fetchResponse;
 
   beforeEach(() => {
     resource = {
       name: chance.string(),
       version: chance.string({ min: 12 }),
       type: chance.string(),
+      uri: chance.string(),
+    };
+    fetchResponse = {
+      data: {
+        originals: chance.string(),
+      },
+      loading: false,
     };
 
     clearResource = jest.fn();
+    useFetch.mockReturnValue(fetchResponse);
 
     render(
       <SelectedResource resource={resource} clearResource={clearResource} />
     );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   it("should render the resource name", () => {
@@ -50,6 +65,14 @@ describe("SelectedResource", () => {
     expect(clearResource).toHaveBeenCalledTimes(1);
   });
 
+  it("should call to fetch the occurrence data when a resource is selected", () => {
+    expect(useFetch)
+      .toHaveBeenCalledTimes(1)
+      .toHaveBeenCalledWith("/api/occurrences", {
+        resourceUri: resource.uri,
+      });
+  });
+
   it("should render a button to toggle the resource details", () => {
     const renderedButton = screen.getByRole("button", {
       name: "Show Resource Details",
@@ -62,5 +85,9 @@ describe("SelectedResource", () => {
       screen.getByText(resource.version.substring(0, 12))
     ).toBeInTheDocument();
     expect(screen.getByText(resource.type)).toBeInTheDocument();
+    expect(screen.getByText(/occurrence data/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(JSON.stringify(fetchResponse.data.originals, null, 2))
+    ).toBeInTheDocument();
   });
 });

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -29,8 +29,14 @@ describe("occurrence-utils", () => {
 
       const resourceUri = buildOccurrence.build.provenance.builtArtifacts[0].id;
 
+      const allOccurrences = [
+        buildOccurrence,
+        deploymentOccurrence,
+        randomOccurrence,
+      ];
+
       const mappedOccurrences = mapOccurrencesToSections(
-        [buildOccurrence, deploymentOccurrence, randomOccurrence],
+        allOccurrences,
         resourceUri
       );
 
@@ -38,6 +44,9 @@ describe("occurrence-utils", () => {
       expect(mappedOccurrences.deploy).toHaveLength(1);
       expect(mappedOccurrences.other).toHaveLength(1);
       expect(mappedOccurrences.other).toContain(randomOccurrence);
+      expect(mappedOccurrences.originals).toEqual({
+        occurrences: allOccurrences,
+      });
     });
 
     describe("vulnerabilities", () => {

--- a/test/pages/playground.spec.js
+++ b/test/pages/playground.spec.js
@@ -212,6 +212,8 @@ describe("PolicyPlayground", () => {
 
     describe("Evaluation", () => {
       it("should call to the correct endpoint", async () => {
+        fetch.mockClear();
+        fetchResponse.json.mockClear();
         const renderedEvaluateButton = screen.getByRole("button", {
           name: "Evaluate",
         });


### PR DESCRIPTION
* Shows the occurrence data for a resource in the policy playground, similar to showing rego code for the selected policy
* Sets height of occurrence data and rego code in playground, can be expanded vertically
* Fixes a failing cypress test