### PR TITLE
Fix chart promotion message

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -89,4 +89,4 @@ jobs:
         with:
           repo: rode/charts
           token: ${{ secrets.GITOPS_TOKEN }}
-          message: "update Rode app version to ${{ steps.tag.outputs.TAG }}"
+          message: "update rode-ui app version to ${{ steps.tag.outputs.TAG }}"


### PR DESCRIPTION
The latest release opened https://github.com/rode/charts/pull/57, which had a PR title indicating it was bumping Rode and not Rode UI. 