### PR TITLE
Group scans by the note name

### DIFF
--- a/cypress/fixtures/resources.json
+++ b/cypress/fixtures/resources.json
@@ -252,7 +252,7 @@
                       "uri": "harbor.localhost/library/nginx@sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
                       "contentHash": null
                     },
-                    "noteName": "projects/rode/notes/harbor",
+                    "noteName": "projects/rode/notes/harbor-bd7a9748-2522-4b0c-82ff-fb0c6a5f57b4",
                     "kind": "DISCOVERY",
                     "remediation": "",
                     "createTime": "2021-02-08T19:48:11Z",
@@ -273,7 +273,7 @@
                       "uri": "harbor.localhost/library/nginx@sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
                       "contentHash": null
                     },
-                    "noteName": "projects/rode/notes/harbor",
+                    "noteName": "projects/rode/notes/harbor-bd7a9748-2522-4b0c-82ff-fb0c6a5f57b4",
                     "kind": "DISCOVERY",
                     "remediation": "",
                     "createTime": "2021-02-08T19:48:18Z",
@@ -294,7 +294,7 @@
                       "uri": "harbor.localhost/library/nginx@sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
                       "contentHash": null
                     },
-                    "noteName": "projects/rode/notes/harbor",
+                    "noteName": "projects/rode/notes/harbor-bd7a9748-2522-4b0c-82ff-fb0c6a5f57b4",
                     "kind": "VULNERABILITY",
                     "remediation": "",
                     "createTime": "2021-02-08T19:48:18Z",
@@ -361,7 +361,7 @@
                       "uri": "harbor.localhost/library/nginx@sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
                       "contentHash": null
                     },
-                    "noteName": "projects/rode/notes/harbor",
+                    "noteName": "projects/rode/notes/harbor-bd7a9748-2522-4b0c-82ff-fb0c6a5f57b4",
                     "kind": "VULNERABILITY",
                     "remediation": "",
                     "createTime": "2021-02-08T19:48:18Z",
@@ -420,7 +420,7 @@
                       "uri": "harbor.localhost/library/nginx@sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
                       "contentHash": null
                     },
-                    "noteName": "projects/rode/notes/harbor",
+                    "noteName": "projects/rode/notes/harbor-bd7a9748-2522-4b0c-82ff-fb0c6a5f57b4",
                     "kind": "VULNERABILITY",
                     "remediation": "",
                     "createTime": "2021-02-08T19:48:18Z",
@@ -479,7 +479,7 @@
                       "uri": "harbor.localhost/library/nginx@sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
                       "contentHash": null
                     },
-                    "noteName": "projects/rode/notes/harbor",
+                    "noteName": "projects/rode/notes/harbor-bd7a9748-2522-4b0c-82ff-fb0c6a5f57b4",
                     "kind": "VULNERABILITY",
                     "remediation": "",
                     "createTime": "2021-02-08T19:48:18Z",

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -54,23 +54,19 @@ describe("occurrence-utils", () => {
         let startScanOccurrence,
           endScanOccurrence,
           matchingVulnerability,
-          scanEndTime;
+          noteName;
 
         beforeEach(() => {
-          let scanStartTime = chance.timestamp();
-          scanEndTime = scanStartTime + 2;
+          noteName = chance.string();
 
-          startScanOccurrence = createMockOccurrence(
-            "DISCOVERY",
-            scanStartTime
-          );
+          startScanOccurrence = createMockOccurrence("DISCOVERY", noteName);
           startScanOccurrence.discovered.discovered.analysisStatus = "SCANNING";
-          endScanOccurrence = createMockOccurrence("DISCOVERY", scanEndTime);
+          endScanOccurrence = createMockOccurrence("DISCOVERY", noteName);
           endScanOccurrence.discovered.discovered.analysisStatus =
             "FINISHED_SUCCESS";
           matchingVulnerability = createMockOccurrence(
             "VULNERABILITY",
-            scanEndTime
+            noteName
           );
         });
 
@@ -140,11 +136,11 @@ describe("occurrence-utils", () => {
         });
 
         it("should sort the vulnerabilities by their severity level", () => {
-          const lowSev = createMockOccurrence("VULNERABILITY", scanEndTime);
+          const lowSev = createMockOccurrence("VULNERABILITY", noteName);
           lowSev.vulnerability.effectiveSeverity = "LOW";
-          const medSev = createMockOccurrence("VULNERABILITY", scanEndTime);
+          const medSev = createMockOccurrence("VULNERABILITY", noteName);
           medSev.vulnerability.effectiveSeverity = "MEDIUM";
-          const highSev = createMockOccurrence("VULNERABILITY", scanEndTime);
+          const highSev = createMockOccurrence("VULNERABILITY", noteName);
           highSev.vulnerability.effectiveSeverity = "HIGH";
 
           const { secure } = mapOccurrencesToSections([

--- a/test/testing-utils/mocks.js
+++ b/test/testing-utils/mocks.js
@@ -119,9 +119,9 @@ const mockDetailsMap = {
 
 export const createMockOccurrence = (
   kind = chance.pickone(Object.keys(mockDetailsMap)),
-  createTime = chance.timestamp()
+  noteName = `projects/rode/notes/${chance.string()}`
 ) => {
-  const kindSpecificDetails = mockDetailsMap[kind]?.(createTime);
+  const kindSpecificDetails = mockDetailsMap[kind]?.();
 
   return {
     name: `projects/rode/occurrences/${chance.guid()}`,
@@ -130,10 +130,10 @@ export const createMockOccurrence = (
       uri: createMockResourceUri(),
       contentHash: null,
     },
-    noteName: "projects/rode/notes/harbor",
-    kind: kind,
+    noteName,
+    kind,
     remediation: "",
-    createTime: createTime,
+    createTime: chance.timestamp(),
     updateTime: null,
     ...kindSpecificDetails,
   };


### PR DESCRIPTION
Closes #93 

Groups vulnerability scans by the `noteName` instead of the `createTime`