### PR TITLE
Version Searching, small UI and performance enhancements

### DIFF
--- a/components/Drawer.js
+++ b/components/Drawer.js
@@ -34,11 +34,12 @@ const Drawer = (props) => {
   };
 
   useEffect(() => {
-    document.addEventListener("mousedown", closeDrawerWhenClickingOutside);
-    return () => {
+    if (isOpen) {
+      document.addEventListener("mousedown", closeDrawerWhenClickingOutside);
+    } else {
       document.removeEventListener("mousedown", closeDrawerWhenClickingOutside);
-    };
-  }, []);
+    }
+  }, [isOpen]);
 
   return (
     <div

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -79,14 +79,18 @@ const Header = () => {
   }, [router]);
 
   useEffect(() => {
-    document.addEventListener("mousedown", closeNavigationWhenClickingOutside);
-    return () => {
+    if (showNavigation) {
+      document.addEventListener(
+        "mousedown",
+        closeNavigationWhenClickingOutside
+      );
+    } else {
       document.removeEventListener(
         "mousedown",
         closeNavigationWhenClickingOutside
       );
-    };
-  }, []);
+    }
+  }, [showNavigation]);
 
   return (
     <header className={`${styles.container} ${styles[theme]}`} ref={ref}>

--- a/components/playground/ResourceVersionSearchAndResults.js
+++ b/components/playground/ResourceVersionSearchAndResults.js
@@ -18,7 +18,10 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Playground.module.scss";
 import Loading from "components/Loading";
-import { getResourceDetails } from "utils/resource-utils";
+import {
+  buildResourceVersionQueryParams,
+  getResourceDetails,
+} from "utils/resource-utils";
 import { resourceActions } from "reducers/resources";
 import { useResources } from "providers/resources";
 import { usePaginatedFetch } from "hooks/usePaginatedFetch";
@@ -27,18 +30,6 @@ import { PLAYGROUND_SEARCH_PAGE_SIZE, SEARCH_ALL } from "utils/constants";
 import ResourceVersion from "components/resources/ResourceVersion";
 import LabelWithValue from "components/LabelWithValue";
 import ResourceVersionSearchBar from "components/resources/ResourceVersionSearchBar";
-
-const buildSearchParams = (genericName, searchTerm) => {
-  const params = {
-    id: genericName,
-  };
-
-  if (searchTerm && searchTerm !== SEARCH_ALL) {
-    params.filter = `version.contains("${searchTerm}")`;
-  }
-
-  return params;
-};
 
 const ResourceVersionSearchAndResults = ({
   genericResource,
@@ -53,7 +44,10 @@ const ResourceVersionSearchAndResults = ({
 
   const { data, loading, isLastPage, goToNextPage } = usePaginatedFetch(
     versionSearch ? "/api/resource-versions" : null,
-    buildSearchParams(genericResource.id, state.versionSearchTerm),
+    buildResourceVersionQueryParams(
+      genericResource.id,
+      state.versionSearchTerm
+    ),
     PLAYGROUND_SEARCH_PAGE_SIZE
   );
 

--- a/components/resources/ChangeVersionDrawer.js
+++ b/components/resources/ChangeVersionDrawer.js
@@ -162,7 +162,6 @@ const ChangeVersionDrawer = (props) => {
     </Drawer>
   );
 };
-
 ChangeVersionDrawer.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   closeDrawer: PropTypes.func.isRequired,

--- a/pages/index.js
+++ b/pages/index.js
@@ -64,7 +64,7 @@ const Home = () => {
           }
           helpText={
             <>
-              You can search by name, version, or{" "}
+              You can search by resource name or{" "}
               <Link href={`/resources?search=${SEARCH_ALL}`}>
                 view all resources
               </Link>

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -92,7 +92,7 @@ const Resources = () => {
           onSubmit={onSubmit}
           helpText={
             <>
-              You can search by name, version, or{" "}
+              You can search by name or{" "}
               <button
                 type={"button"}
                 onClick={viewAllResources}

--- a/styles/modules/Drawer.module.scss
+++ b/styles/modules/Drawer.module.scss
@@ -115,6 +115,18 @@
   margin: 0 auto 1rem;
 }
 
+.versionSearchContainer {
+  width: 90%;
+  margin: 0 auto;
+}
+
+.viewAllButton {
+  font-size: 0.85rem;
+  min-height: fit-content;
+  padding: 0.25rem;
+  margin-left: auto;
+}
+
 .notFoundMessage {
   margin: 1rem auto;
 }

--- a/test/components/Drawer.spec.js
+++ b/test/components/Drawer.spec.js
@@ -20,7 +20,7 @@ import Drawer from "components/Drawer";
 import userEvent from "@testing-library/user-event";
 
 describe("Drawer", () => {
-  let isOpen, onClose, children, unmount, rerender;
+  let isOpen, onClose, children, rerender;
 
   beforeEach(() => {
     jest.spyOn(document, "addEventListener");
@@ -37,7 +37,6 @@ describe("Drawer", () => {
         </Drawer>
       </>
     );
-    unmount = utils.unmount;
     rerender = utils.rerender;
   });
 
@@ -71,7 +70,15 @@ describe("Drawer", () => {
       .toHaveBeenCalledTimes(1)
       .toHaveBeenCalledWith("mousedown", expect.any(Function));
 
-    unmount();
+    isOpen = false;
+    rerender(
+      <>
+        <p>trigger</p>
+        <Drawer isOpen={isOpen} onClose={onClose}>
+          <p>{children}</p>
+        </Drawer>
+      </>
+    );
     expect(document.removeEventListener).toHaveBeenCalledWith(
       "mousedown",
       expect.any(Function)

--- a/test/components/layout/Header.spec.js
+++ b/test/components/layout/Header.spec.js
@@ -20,39 +20,30 @@ import userEvent from "@testing-library/user-event";
 import Header from "components/layout/Header";
 
 describe("Header", () => {
-  let unmount;
   beforeEach(() => {
     jest.spyOn(document, "addEventListener");
     jest.spyOn(document, "removeEventListener");
-    const utils = render(
+    render(
       <div>
         <Header />
         <p>Trigger</p>
       </div>
     );
-
-    unmount = utils.unmount;
   });
 
   it("should add an event listener to listen to clicks outside of the nav menu", () => {
+    act(() => {
+      userEvent.click(screen.getByLabelText(/^toggle navigation/i));
+    });
     expect(document.addEventListener).toHaveBeenCalledWith(
       "mousedown",
       expect.any(Function)
     );
-    const navigationContainer = screen.getByTestId("navigationContainer");
-    expect(navigationContainer).toHaveClass("hidden");
-
-    act(() => {
-      userEvent.click(screen.getByTitle(/menu/i));
-    });
-    expect(navigationContainer).not.toHaveClass("hidden");
 
     act(() => {
       userEvent.click(screen.getByText("Trigger"));
     });
-    expect(navigationContainer).toHaveClass("hidden");
 
-    unmount();
     expect(document.removeEventListener).toHaveBeenCalledWith(
       "mousedown",
       expect.any(Function)

--- a/test/components/playground/PolicySearchAndResults.spec.js
+++ b/test/components/playground/PolicySearchAndResults.spec.js
@@ -80,11 +80,15 @@ describe("PolicySearchAndResults", () => {
   it("should render the button to open the search drawer", () => {
     const renderedButton = screen.getByLabelText(/search for policies/i);
     expect(renderedButton).toBeInTheDocument();
-    expect(screen.getByTestId("drawer")).toHaveClass("closedDrawer");
+
+    const renderedDrawer = screen.getByTestId("drawer");
+    expect(renderedDrawer).toHaveClass("closedDrawer");
 
     userEvent.click(renderedButton);
+    expect(renderedDrawer).toHaveClass("openDrawer");
 
-    expect(screen.getByTestId("drawer")).toHaveClass("openDrawer");
+    userEvent.click(screen.getByLabelText(/close drawer/i));
+    expect(renderedDrawer).toHaveClass("closedDrawer");
   });
 
   it("should render the search bar", () => {

--- a/test/components/resources/ResourceSelectionDrawer.spec.js
+++ b/test/components/resources/ResourceSelectionDrawer.spec.js
@@ -89,6 +89,9 @@ describe("ResourceSelectionDrawer", () => {
         type: "SET_VERSION_SEARCH_TERM",
         data: "",
       });
+
+    userEvent.click(screen.getByLabelText(/close drawer/i));
+    expect(drawer).toHaveClass("closedDrawer");
   });
 
   it("should show the drawer header", () => {

--- a/test/pages/resources/[resourceUri].spec.js
+++ b/test/pages/resources/[resourceUri].spec.js
@@ -132,7 +132,9 @@ describe("Resource Details page", () => {
       router.query.resourceUri
     );
 
-    expect(screen.getByText(resourceName)).toBeInTheDocument();
+    expect(
+      screen.getByText(resourceName, { selector: "h1" })
+    ).toBeInTheDocument();
     expect(screen.getByText("Type")).toBeInTheDocument();
     expect(screen.getByText(resourceLabel)).toBeInTheDocument();
     expect(screen.getByText("Version")).toBeInTheDocument();
@@ -150,7 +152,7 @@ describe("Resource Details page", () => {
     userEvent.click(renderedButton);
 
     expect(
-      screen.getByText(/no versions found matching the resource/i)
+      screen.getByText(/no versions found matching the given criteria./i)
     ).toBeInTheDocument();
   });
 

--- a/test/pages/resources/[resourceUri].spec.js
+++ b/test/pages/resources/[resourceUri].spec.js
@@ -15,7 +15,7 @@
  */
 
 import React from "react";
-import { render, screen } from "test/testing-utils/renderer";
+import { render, screen, act } from "test/testing-utils/renderer";
 import Resource from "pages/resources/[resourceUri]";
 import { useRouter } from "next/router";
 import { createMockResourceUri } from "test/testing-utils/mocks";
@@ -151,9 +151,12 @@ describe("Resource Details page", () => {
     expect(renderedButton).toBeInTheDocument();
     userEvent.click(renderedButton);
 
-    expect(
-      screen.getByText(/no versions found matching the given criteria./i)
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("drawer")).toHaveClass("openDrawer");
+
+    act(() => {
+      userEvent.click(screen.getByLabelText(/close drawer/i));
+    });
+    expect(screen.getByTestId("drawer")).toHaveClass("closedDrawer");
   });
 
   it("should render a button to use the resource in the policy playground", () => {

--- a/test/utils/resource-utils.spec.js
+++ b/test/utils/resource-utils.spec.js
@@ -16,6 +16,7 @@
 
 import {
   buildResourceQueryParams,
+  buildResourceVersionQueryParams,
   getResourceDetails,
 } from "utils/resource-utils";
 
@@ -281,6 +282,37 @@ describe("resource utils", () => {
       expect(actual).toEqual({
         resourceTypes: typeFilters.map(({ value }) => value),
       });
+    });
+  });
+
+  describe("buildResourceVersionQueryParams", () => {
+    let genericName, searchTerm, actual;
+
+    beforeEach(() => {
+      genericName = chance.string();
+      searchTerm = "";
+    });
+
+    it("should return the generic name parameters", () => {
+      actual = buildResourceVersionQueryParams(genericName, searchTerm);
+      expect(actual).toEqual({ id: genericName });
+    });
+
+    it("should return the search term param if searching for a term other than 'all'", () => {
+      searchTerm = chance.string();
+
+      actual = buildResourceVersionQueryParams(genericName, searchTerm);
+      expect(actual).toEqual({
+        id: genericName,
+        filter: `version.contains("${searchTerm}")`,
+      });
+    });
+
+    it("should not return the search term param if searching for 'all'", () => {
+      searchTerm = "all";
+
+      actual = buildResourceVersionQueryParams(genericName, searchTerm);
+      expect(actual).toEqual({ id: genericName });
     });
   });
 });

--- a/utils/resource-utils.js
+++ b/utils/resource-utils.js
@@ -168,3 +168,15 @@ export const buildResourceQueryParams = (searchTerm, typeFilters) => {
 
   return params;
 };
+
+export const buildResourceVersionQueryParams = (genericName, searchTerm) => {
+  const params = {
+    id: genericName,
+  };
+
+  if (searchTerm && searchTerm !== SEARCH_ALL) {
+    params.filter = `version.contains("${searchTerm}")`;
+  }
+
+  return params;
+};


### PR DESCRIPTION
* Adds version searching to the change version drawer when viewing a resource
* Change how event listeners are added/removed - sometimes my long running environment would have too many listeners and this should fix that.
* Update wording on resource search to remove references about searching by the version. This may be [added to rode](https://github.com/rode/rode/issues/91) later, but I'm removing for now to avoid confusion.
