### PR TITLE
Consume notes for scans

### DIFF
--- a/components/LabelWithValue.js
+++ b/components/LabelWithValue.js
@@ -19,14 +19,16 @@ import PropTypes from "prop-types";
 import styles from "styles/modules/Typography.module.scss";
 
 const LabelWithValue = (props) => {
-  const { label, value, vertical = false, className = "" } = props;
+  const { label, value, vertical = false, className = "", as = "p" } = props;
 
   if (!value) {
     return null;
   }
 
+  const Text = as;
+
   return (
-    <p
+    <Text
       className={` ${
         vertical
           ? styles.verticalLabelWithValueContainer
@@ -35,7 +37,7 @@ const LabelWithValue = (props) => {
     >
       <span className={styles.label}>{label}</span>
       <span className={styles.value}>{value}</span>
-    </p>
+    </Text>
   );
 };
 
@@ -44,6 +46,7 @@ LabelWithValue.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   className: PropTypes.string,
   vertical: PropTypes.bool,
+  as: PropTypes.oneOf(["h1", "h2", "h3", "h4", "h5", "h6", "span"]),
 };
 
 export default LabelWithValue;

--- a/components/LabelWithValue.js
+++ b/components/LabelWithValue.js
@@ -46,7 +46,7 @@ LabelWithValue.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   className: PropTypes.string,
   vertical: PropTypes.bool,
-  as: PropTypes.oneOf(["h1", "h2", "h3", "h4", "h5", "h6", "span"]),
+  as: PropTypes.oneOf(["h1", "h2", "h3", "h4", "h5", "h6", "span", "p"]),
 };
 
 export default LabelWithValue;

--- a/components/occurrences/BuildOccurrenceSection.js
+++ b/components/occurrences/BuildOccurrenceSection.js
@@ -66,6 +66,7 @@ const BuildOccurrenceSection = ({ occurrences, type }) => {
                       <ResourceVersion version={producedArtifactVersions[0]} />
                     )
                   }
+                  as={"span"}
                 />
                 <ExternalLink
                   href={occurrence.sourceUri}

--- a/components/occurrences/SecureOccurrenceSection.js
+++ b/components/occurrences/SecureOccurrenceSection.js
@@ -29,8 +29,6 @@ const SecureOccurrenceSection = ({ occurrences }) => {
     return null;
   }
 
-  console.log('occurrences', occurrences);
-
   return (
     <div className={styles.sectionContainer}>
       <div className={styles.sectionTitle}>

--- a/components/occurrences/SecureOccurrenceSection.js
+++ b/components/occurrences/SecureOccurrenceSection.js
@@ -29,6 +29,8 @@ const SecureOccurrenceSection = ({ occurrences }) => {
     return null;
   }
 
+  console.log('occurrences', occurrences);
+
   return (
     <div className={styles.sectionContainer}>
       <div className={styles.sectionTitle}>
@@ -39,7 +41,7 @@ const SecureOccurrenceSection = ({ occurrences }) => {
         <OccurrencePreview
           key={occurrence.name}
           currentOccurrence={occurrence}
-          mainText={"Vulnerability Scan"}
+          mainText={occurrence.notes?.shortDescription || "Vulnerability Scan"}
           timestamp={
             occurrence.completed
               ? `Completed at ${dayjs(occurrence.completed).format(

--- a/components/occurrences/VulnerabilityOccurrenceDetails.js
+++ b/components/occurrences/VulnerabilityOccurrenceDetails.js
@@ -22,48 +22,62 @@ import { DATE_TIME_FORMAT } from "utils/constants";
 import { getVulnerabilityBreakdown } from "utils/occurrence-utils";
 import OccurrenceCodeModal from "./OccurrenceCodeModal";
 import VulnerabilityCard from "./VulnerabilityCard";
+import ExternalLink from "components/ExternalLink";
 
 const VulnerabilityOccurrenceDetails = ({ occurrence }) => {
   return (
     <div>
-      <div className={styles.detailSummary}>
+      <div className={ styles.detailSummary }>
         <div>
-          <p className={styles.title}>Vulnerability Scan</p>
-          {occurrence.completed ? (
+          <p className={ styles.title }>{ occurrence.notes?.shortDescription || "Vulnerability Scan" }</p>
+          {
+            occurrence.notes?.longDescription &&
+            <p className={ styles.vulnerabilitySubtext }>{ occurrence.notes?.longDescription }</p>
+          }
+          { occurrence.completed ? (
             <>
-              <p>{occurrence.vulnerabilities.length} vulnerabilities found</p>
-              <p className={styles.vulnerabilityBreakdown}>
-                {getVulnerabilityBreakdown(occurrence.vulnerabilities)}
+              <p>{ occurrence.vulnerabilities.length } vulnerabilities found</p>
+              <p className={ styles.vulnerabilitySubtext }>
+                { getVulnerabilityBreakdown(occurrence.vulnerabilities) }
               </p>
             </>
           ) : (
             <p>Scan In Progress</p>
-          )}
+          ) }
+          {
+            occurrence.notes?.relatedUrl?.map((url) => (
+              <ExternalLink
+                key={url.url}
+                href={ url.url }
+                label={ url.label }
+              />
+            ))
+          }
         </div>
-        <div className={styles.rightDetails}>
-          <p className={styles.timestamps}>
-            Started {dayjs(occurrence.started).format(DATE_TIME_FORMAT)}
+        <div className={ styles.rightDetails }>
+          <p className={ styles.timestamps }>
+            Started { dayjs(occurrence.started).format(DATE_TIME_FORMAT) }
           </p>
-          <p className={styles.timestamps}>
-            Completed{" "}
-            {occurrence.completed
+          <p className={ styles.timestamps }>
+            Completed{ " " }
+            { occurrence.completed
               ? dayjs(occurrence.completed).format(DATE_TIME_FORMAT)
-              : "N/A"}
+              : "N/A" }
           </p>
-          <OccurrenceCodeModal json={occurrence.originals} />
+          <OccurrenceCodeModal json={ occurrence.originals } />
         </div>
       </div>
-      <div className={styles.detailContentContainer}>
-        {occurrence.vulnerabilities.map((vuln) => (
-          <VulnerabilityCard key={vuln.name} vulnerability={vuln} />
-        ))}
-      </div>
-    </div>
-  );
-};
+      <div className={ styles.detailContentContainer }>
+      { occurrence.vulnerabilities.map((vuln) => (
+        <VulnerabilityCard key={ vuln.name } vulnerability={ vuln } />
+        )) }
+        </div>
+        </div>
+        );
+      };
 
 VulnerabilityOccurrenceDetails.propTypes = {
-  occurrence: PropTypes.object.isRequired,
+  occurrence: PropTypes.object.isRequired
 };
 
 export default VulnerabilityOccurrenceDetails;

--- a/components/occurrences/VulnerabilityOccurrenceDetails.js
+++ b/components/occurrences/VulnerabilityOccurrenceDetails.js
@@ -27,57 +27,54 @@ import ExternalLink from "components/ExternalLink";
 const VulnerabilityOccurrenceDetails = ({ occurrence }) => {
   return (
     <div>
-      <div className={ styles.detailSummary }>
+      <div className={styles.detailSummary}>
         <div>
-          <p className={ styles.title }>{ occurrence.notes?.shortDescription || "Vulnerability Scan" }</p>
-          {
-            occurrence.notes?.longDescription &&
-            <p className={ styles.vulnerabilitySubtext }>{ occurrence.notes?.longDescription }</p>
-          }
-          { occurrence.completed ? (
+          <p className={styles.title}>
+            {occurrence.notes?.shortDescription || "Vulnerability Scan"}
+          </p>
+          {occurrence.notes?.longDescription && (
+            <p className={styles.vulnerabilitySubtext}>
+              {occurrence.notes?.longDescription}
+            </p>
+          )}
+          {occurrence.completed ? (
             <>
-              <p>{ occurrence.vulnerabilities.length } vulnerabilities found</p>
-              <p className={ styles.vulnerabilitySubtext }>
-                { getVulnerabilityBreakdown(occurrence.vulnerabilities) }
+              <p>{occurrence.vulnerabilities.length} vulnerabilities found</p>
+              <p className={styles.vulnerabilitySubtext}>
+                {getVulnerabilityBreakdown(occurrence.vulnerabilities)}
               </p>
             </>
           ) : (
             <p>Scan In Progress</p>
-          ) }
-          {
-            occurrence.notes?.relatedUrl?.map((url) => (
-              <ExternalLink
-                key={url.url}
-                href={ url.url }
-                label={ url.label }
-              />
-            ))
-          }
+          )}
+          {occurrence.notes?.relatedUrl?.map((url) => (
+            <ExternalLink key={url.url} href={url.url} label={url.label} />
+          ))}
         </div>
-        <div className={ styles.rightDetails }>
-          <p className={ styles.timestamps }>
-            Started { dayjs(occurrence.started).format(DATE_TIME_FORMAT) }
+        <div className={styles.rightDetails}>
+          <p className={styles.timestamps}>
+            Started {dayjs(occurrence.started).format(DATE_TIME_FORMAT)}
           </p>
-          <p className={ styles.timestamps }>
-            Completed{ " " }
-            { occurrence.completed
+          <p className={styles.timestamps}>
+            Completed{" "}
+            {occurrence.completed
               ? dayjs(occurrence.completed).format(DATE_TIME_FORMAT)
-              : "N/A" }
+              : "N/A"}
           </p>
-          <OccurrenceCodeModal json={ occurrence.originals } />
+          <OccurrenceCodeModal json={occurrence.originals} />
         </div>
       </div>
-      <div className={ styles.detailContentContainer }>
-      { occurrence.vulnerabilities.map((vuln) => (
-        <VulnerabilityCard key={ vuln.name } vulnerability={ vuln } />
-        )) }
-        </div>
-        </div>
-        );
-      };
+      <div className={styles.detailContentContainer}>
+        {occurrence.vulnerabilities.map((vuln) => (
+          <VulnerabilityCard key={vuln.name} vulnerability={vuln} />
+        ))}
+      </div>
+    </div>
+  );
+};
 
 VulnerabilityOccurrenceDetails.propTypes = {
-  occurrence: PropTypes.object.isRequired
+  occurrence: PropTypes.object.isRequired,
 };
 
 export default VulnerabilityOccurrenceDetails;

--- a/pages/api/occurrences.js
+++ b/pages/api/occurrences.js
@@ -33,7 +33,7 @@ export default async (req, res) => {
     const response = await fetch(
       `${rodeUrl}/v1alpha1/versioned-resource-occurrences?resourceUri=${encodeURIComponent(
         resourceUri
-      )}&pageSize=1000`
+      )}&fetchRelatedNotes=true&pageSize=1000`
     );
 
     if (!response.ok) {
@@ -51,7 +51,8 @@ export default async (req, res) => {
 
     const occurrences = mapOccurrencesToSections(
       listOccurrencesResponse.occurrences,
-      resourceUri
+      resourceUri,
+      listOccurrencesResponse.relatedNotes
     );
 
     res.status(StatusCodes.OK).json(occurrences);

--- a/pages/api/utils/occurrence-utils.js
+++ b/pages/api/utils/occurrence-utils.js
@@ -76,7 +76,7 @@ const matchAndMapVulnerabilities = (occurrences, notes) => {
 
   const scanEnds = discoveryOccurrences.filter(
     (occurrence) =>
-      occurrence.discovered.discovered.analysisStatus === "FINISHED_SUCCESS"
+      occurrence.discovered.discovered.analysisStatus.includes("FINISHED")
   );
 
   const matchedTfSecScans = tfSecScanStarts

--- a/pages/api/utils/occurrence-utils.js
+++ b/pages/api/utils/occurrence-utils.js
@@ -52,7 +52,7 @@ const mapVulnerabilities = (occurrences) => {
   return sortByVulnerability(mapped);
 };
 
-const matchAndMapVulnerabilities = (occurrences) => {
+const matchAndMapVulnerabilities = (occurrences, notes) => {
   const unmatchedOccurrences = [];
 
   const discoveryOccurrences = occurrences.filter(
@@ -93,12 +93,15 @@ const matchAndMapVulnerabilities = (occurrences) => {
           vulnerability.createTime === startScan.createTime
       );
 
+      const matchingNotes = notes[startScan.noteName];
+
       if (!endScan) {
         return {
           name: startScan.name,
           started: startScan.createTime,
           completed: null,
           vulnerabilities: matchingVulnerabilities,
+          notes: matchingNotes,
           originals: {
             occurrences: [startScan, ...matchingVulnerabilities],
           },
@@ -110,6 +113,7 @@ const matchAndMapVulnerabilities = (occurrences) => {
         started: startScan.createTime,
         completed: endScan.createTime,
         vulnerabilities: mapVulnerabilities(matchingVulnerabilities),
+        notes: matchingNotes,
         originals: {
           occurrences: [startScan, endScan, ...matchingVulnerabilities],
         },
@@ -126,12 +130,15 @@ const matchAndMapVulnerabilities = (occurrences) => {
       );
       const endScan = scanEnds.find((endScan) => endScan.noteName === noteName);
 
+      const matchingNotes = notes[startScan.noteName];
+
       if (!endScan) {
         return {
           name: startScan.name,
           started: startScan.createTime,
           completed: null,
           vulnerabilities: matchingVulnerabilities,
+          notes: matchingNotes,
           originals: {
             occurrences: [startScan, ...matchingVulnerabilities],
           },
@@ -143,6 +150,7 @@ const matchAndMapVulnerabilities = (occurrences) => {
         started: startScan.createTime,
         completed: endScan.createTime,
         vulnerabilities: mapVulnerabilities(matchingVulnerabilities),
+        notes: matchingNotes,
         originals: {
           occurrences: [startScan, endScan, ...matchingVulnerabilities],
         },
@@ -227,7 +235,7 @@ const mapDeployments = (occurrences) => {
   });
 };
 
-export const mapOccurrencesToSections = (occurrences, resourceUri) => {
+export const mapOccurrencesToSections = (occurrences, resourceUri, notes) => {
   let buildOccurrences = [];
   let vulnerabilityOccurrences = [];
   let deploymentOccurrences = [];
@@ -259,7 +267,8 @@ export const mapOccurrencesToSections = (occurrences, resourceUri) => {
   });
 
   const { vulnerabilities, other } = matchAndMapVulnerabilities(
-    vulnerabilityOccurrences
+    vulnerabilityOccurrences,
+    notes
   );
 
   return {

--- a/pages/api/utils/occurrence-utils.js
+++ b/pages/api/utils/occurrence-utils.js
@@ -74,9 +74,8 @@ const matchAndMapVulnerabilities = (occurrences, notes) => {
     (scan) => !scan.noteName.includes("tfsec")
   );
 
-  const scanEnds = discoveryOccurrences.filter(
-    (occurrence) =>
-      occurrence.discovered.discovered.analysisStatus.includes("FINISHED")
+  const scanEnds = discoveryOccurrences.filter((occurrence) =>
+    occurrence.discovered.discovered.analysisStatus.includes("FINISHED")
   );
 
   const matchedTfSecScans = tfSecScanStarts

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -46,6 +46,8 @@ const Resource = () => {
     resourceUri,
   });
 
+  console.log("data", data);
+
   useSafeLayoutEffect(() => {
     dispatch({
       type: resourceActions.SET_OCCURRENCE_DETAILS,

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -46,8 +46,6 @@ const Resource = () => {
     resourceUri,
   });
 
-  console.log("data", data);
-
   useSafeLayoutEffect(() => {
     dispatch({
       type: resourceActions.SET_OCCURRENCE_DETAILS,

--- a/styles/modules/OccurrenceDetails.module.scss
+++ b/styles/modules/OccurrenceDetails.module.scss
@@ -46,7 +46,6 @@ $SIDE_SPACING: 1rem;
 
 .title {
   font-size: 1.5rem;
-  margin-bottom: 1rem;
 }
 
 .rightMargin {
@@ -138,9 +137,10 @@ $SIDE_SPACING: 1rem;
   }
 }
 
-.vulnerabilityBreakdown {
+.vulnerabilitySubtext {
   @include desktopAndLarger {
     text-indent: 1rem;
+    margin-bottom: 0.5rem;
   }
 }
 
@@ -202,7 +202,7 @@ $SIDE_SPACING: 1rem;
     color: $DT_SUB_TEXT;
   }
 
-  .vulnerabilityBreakdown {
+  .vulnerabilitySubtext {
     color: $DT_SUB_TEXT;
   }
 
@@ -241,7 +241,7 @@ $SIDE_SPACING: 1rem;
     color: $LT_SUB_TEXT;
   }
 
-  .vulnerabilityBreakdown {
+  .vulnerabilitySubtext {
     color: $LT_SUB_TEXT;
   }
 

--- a/test/components/LabelWithValue.spec.js
+++ b/test/components/LabelWithValue.spec.js
@@ -65,4 +65,13 @@ describe("LabelWithValue", () => {
       "verticalLabelWithValueContainer"
     );
   });
+
+  it("should allow the user to specify a different html tag to render", () => {
+    const type = "h1";
+    rerender(<LabelWithValue label={label} value={value} as={type} />);
+
+    const renderedLabel = screen.getByText(label);
+    expect(renderedLabel).toBeInTheDocument();
+    expect(renderedLabel.closest(type)).toHaveClass("labelWithValueContainer");
+  });
 });

--- a/test/components/occurrences/SecureOccurrenceSection.spec.js
+++ b/test/components/occurrences/SecureOccurrenceSection.spec.js
@@ -79,6 +79,17 @@ describe("SecureOccurrenceSection", () => {
       });
     });
 
+    it("should render the preview with the note description if it exists", () => {
+      const description = chance.string();
+      occurrences[0].notes = {
+        shortDescription: description,
+      };
+
+      rerender(<SecureOccurrenceSection occurrences={occurrences} />);
+
+      expect(screen.getByText(description)).toBeInTheDocument();
+    });
+
     it("should render the preview as 'In Progress' when a scan has not completed", () => {
       occurrences[0].completed = null;
 

--- a/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
+++ b/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
@@ -62,6 +62,45 @@ describe("VulnerabilityOccurrenceDetails", () => {
     ).toBeInTheDocument();
   });
 
+  it("should display the short description of the note if it exists", () => {
+    const shortDescription = chance.string();
+    occurrence.notes = {
+      shortDescription,
+    };
+    rerender(<VulnerabilityOccurrenceDetails occurrence={occurrence} />);
+    expect(screen.getByText(shortDescription)).toBeInTheDocument();
+    expect(screen.queryByText("Vulnerability Scan")).not.toBeInTheDocument();
+  });
+
+  it("should display the long description of the related note if it exists", () => {
+    const longDescription = chance.string();
+    occurrence.notes = {
+      longDescription,
+    };
+    rerender(<VulnerabilityOccurrenceDetails occurrence={occurrence} />);
+    expect(screen.getByText(longDescription)).toBeInTheDocument();
+  });
+
+  it("should display the related urls of the note if they exist", () => {
+    const relatedUrl = chance.n(
+      () => ({
+        url: chance.url(),
+        label: chance.string(),
+      }),
+      chance.d4()
+    );
+    occurrence.notes = {
+      relatedUrl,
+    };
+    rerender(<VulnerabilityOccurrenceDetails occurrence={occurrence} />);
+
+    relatedUrl.forEach((url) => {
+      const renderedUrl = screen.getByText(url.label);
+      expect(renderedUrl).toBeInTheDocument();
+      expect(renderedUrl).toHaveAttribute("href", url.url);
+    });
+  });
+
   it("should show a card for each vulnerability found", () => {
     occurrence.vulnerabilities.forEach((vuln) => {
       expect(screen.getByText(vuln.packageName)).toBeInTheDocument();

--- a/test/pages/api/occurrences.spec.js
+++ b/test/pages/api/occurrences.spec.js
@@ -22,7 +22,7 @@ import { mapOccurrencesToSections } from "pages/api/utils/occurrence-utils";
 
 jest.mock("node-fetch");
 
-describe("/api/resources", () => {
+describe("/api/occurrences", () => {
   let request, response, allOccurrences, rodeResponse, resourceUriParam;
 
   beforeEach(() => {
@@ -90,7 +90,7 @@ describe("/api/resources", () => {
     const createExpectedUrl = (baseUrl) => {
       return `${baseUrl}/v1alpha1/versioned-resource-occurrences?resourceUri=${encodeURIComponent(
         resourceUriParam
-      )}&pageSize=1000`;
+      )}&fetchRelatedNotes=true&pageSize=1000`;
     };
 
     it("should hit the Rode API", async () => {

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -53,10 +53,16 @@ describe("occurrence-utils", () => {
       let startScanOccurrence,
         endScanOccurrence,
         matchingVulnerability,
-        noteName;
+        noteName,
+        notes;
 
       beforeEach(() => {
         noteName = "harbor-scan";
+        notes = {
+          [noteName]: {
+            [chance.string()]: chance.string(),
+          },
+        };
 
         startScanOccurrence = createMockOccurrence("DISCOVERY", noteName);
         startScanOccurrence.discovered.discovered.analysisStatus = "SCANNING";
@@ -68,16 +74,21 @@ describe("occurrence-utils", () => {
 
       describe("harbor scans", () => {
         it("should match up vulnerabilities with a scan start and end", () => {
-          const { secure } = mapOccurrencesToSections([
-            startScanOccurrence,
-            endScanOccurrence,
-            matchingVulnerability,
-            createMockOccurrence("VULNERABILITY"),
-          ]);
+          const { secure } = mapOccurrencesToSections(
+            [
+              startScanOccurrence,
+              endScanOccurrence,
+              matchingVulnerability,
+              createMockOccurrence("VULNERABILITY"),
+            ],
+            chance.string(),
+            notes
+          );
 
           expect(secure).toHaveLength(1);
           expect(secure[0].started).toEqual(startScanOccurrence.createTime);
           expect(secure[0].completed).toEqual(endScanOccurrence.createTime);
+          expect(secure[0].notes).toEqual(notes[noteName]);
           expect(secure[0].originals.occurrences).toContain(
             startScanOccurrence
           );
@@ -93,10 +104,11 @@ describe("occurrence-utils", () => {
             "harbor-scan"
           );
           startScanOccurrence.discovered.discovered.analysisStatus = "SCANNING";
-          const { secure, other } = mapOccurrencesToSections([
-            startScanOccurrence,
-            createMockOccurrence("VULNERABILITY"),
-          ]);
+          const { secure, other } = mapOccurrencesToSections(
+            [startScanOccurrence, createMockOccurrence("VULNERABILITY")],
+            chance.string(),
+            notes
+          );
 
           expect(secure).toHaveLength(1);
           expect(secure[0].completed).toBeNull();
@@ -108,6 +120,11 @@ describe("occurrence-utils", () => {
       describe("tfsec scans", () => {
         beforeEach(() => {
           noteName = "tfsec";
+          notes = {
+            [noteName]: {
+              [chance.string()]: chance.string(),
+            },
+          };
 
           startScanOccurrence = createMockOccurrence("DISCOVERY", noteName);
           startScanOccurrence.discovered.discovered.analysisStatus = "SCANNING";
@@ -123,16 +140,21 @@ describe("occurrence-utils", () => {
         });
 
         it("should match up vulnerabilities with a scan start and end", () => {
-          const { secure } = mapOccurrencesToSections([
-            startScanOccurrence,
-            endScanOccurrence,
-            matchingVulnerability,
-            createMockOccurrence("VULNERABILITY"),
-          ]);
+          const { secure } = mapOccurrencesToSections(
+            [
+              startScanOccurrence,
+              endScanOccurrence,
+              matchingVulnerability,
+              createMockOccurrence("VULNERABILITY"),
+            ],
+            chance.string(),
+            notes
+          );
 
           expect(secure).toHaveLength(1);
           expect(secure[0].started).toEqual(startScanOccurrence.createTime);
           expect(secure[0].completed).toEqual(endScanOccurrence.createTime);
+          expect(secure[0].notes).toEqual(notes[noteName]);
           expect(secure[0].originals.occurrences).toContain(
             startScanOccurrence
           );
@@ -148,10 +170,11 @@ describe("occurrence-utils", () => {
             "tfsec"
           );
           startScanOccurrence.discovered.discovered.analysisStatus = "SCANNING";
-          const { secure, other } = mapOccurrencesToSections([
-            startScanOccurrence,
-            createMockOccurrence("VULNERABILITY"),
-          ]);
+          const { secure, other } = mapOccurrencesToSections(
+            [startScanOccurrence, createMockOccurrence("VULNERABILITY")],
+            chance.string(),
+            notes
+          );
 
           expect(secure).toHaveLength(1);
           expect(secure[0].completed).toBeNull();
@@ -161,12 +184,16 @@ describe("occurrence-utils", () => {
       });
 
       it("should correctly map the vulnerabilities", () => {
-        const { secure } = mapOccurrencesToSections([
-          startScanOccurrence,
-          endScanOccurrence,
-          matchingVulnerability,
-          createMockOccurrence("VULNERABILITY"),
-        ]);
+        const { secure } = mapOccurrencesToSections(
+          [
+            startScanOccurrence,
+            endScanOccurrence,
+            matchingVulnerability,
+            createMockOccurrence("VULNERABILITY"),
+          ],
+          chance.string(),
+          notes
+        );
 
         expect(secure[0].vulnerabilities).toHaveLength(1);
 
@@ -213,11 +240,15 @@ describe("occurrence-utils", () => {
         const highSev = createMockOccurrence("VULNERABILITY", noteName);
         highSev.vulnerability.effectiveSeverity = "HIGH";
 
-        const { secure } = mapOccurrencesToSections([
-          startScanOccurrence,
-          endScanOccurrence,
-          ...chance.shuffle([lowSev, medSev, highSev]),
-        ]);
+        const { secure } = mapOccurrencesToSections(
+          [
+            startScanOccurrence,
+            endScanOccurrence,
+            ...chance.shuffle([lowSev, medSev, highSev]),
+          ],
+          chance.string(),
+          notes
+        );
 
         expect(secure[0].vulnerabilities[0].effectiveSeverity).toBe("HIGH");
         expect(secure[0].vulnerabilities[1].effectiveSeverity).toBe("MEDIUM");

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -68,7 +68,7 @@ describe("occurrence-utils", () => {
         startScanOccurrence.discovered.discovered.analysisStatus = "SCANNING";
         endScanOccurrence = createMockOccurrence("DISCOVERY", noteName);
         endScanOccurrence.discovered.discovered.analysisStatus =
-          "FINISHED_SUCCESS";
+          chance.pickone(["FINISHED_SUCCESS", "FINISHED_FAILED"]);
         matchingVulnerability = createMockOccurrence("VULNERABILITY", noteName);
       });
 

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -67,8 +67,9 @@ describe("occurrence-utils", () => {
         startScanOccurrence = createMockOccurrence("DISCOVERY", noteName);
         startScanOccurrence.discovered.discovered.analysisStatus = "SCANNING";
         endScanOccurrence = createMockOccurrence("DISCOVERY", noteName);
-        endScanOccurrence.discovered.discovered.analysisStatus =
-          chance.pickone(["FINISHED_SUCCESS", "FINISHED_FAILED"]);
+        endScanOccurrence.discovered.discovered.analysisStatus = chance.pickone(
+          ["FINISHED_SUCCESS", "FINISHED_FAILED"]
+        );
         matchingVulnerability = createMockOccurrence("VULNERABILITY", noteName);
       });
 


### PR DESCRIPTION
* Pulls related notes when fetching occurrences and uses those notes to display better information about the vulnerability scan.  
* Also pulls any finished scan, not just the successful ones, to correctly show sonar scans
* Fixes issue with nested p tags causing a react dev warning

Another PR will add note information to the other occurrence types once the other collectors are producing notes that can be consumed.

Closes #104 , Closes #107