### PR TITLE
Policy version updates

### DIFF
--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -50,7 +50,9 @@ const PolicyForm = ({
 
   const [name, setName] = useState(policy.name || "");
   const [description, setDescription] = useState(policy.description || "");
-  const [regoContent, setRegoContent] = useState(policy.regoContent || "");
+  const [regoContent, setRegoContent] = useState(
+    policy?.policy?.regoContent || ""
+  );
 
   const { isValid, validateField, errors } = useFormValidation(schema);
 
@@ -72,7 +74,7 @@ const PolicyForm = ({
     setLoading(true);
     const response = await fetch(endpoint, {
       method,
-      body: JSON.stringify(formData),
+      body: JSON.stringify({ name, description, policy: { regoContent } }),
     });
 
     setLoading(false);

--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -73,6 +73,9 @@ const PolicyForm = ({
     const response = await fetch(endpoint, {
       method,
       body: JSON.stringify(formData),
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
 
     setLoading(false);
@@ -109,6 +112,9 @@ const PolicyForm = ({
       body: JSON.stringify({
         policy: regoContent,
       }),
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
 
     const result = await response.json();

--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -72,7 +72,7 @@ const PolicyForm = ({
     setLoading(true);
     const response = await fetch(endpoint, {
       method,
-      body: JSON.stringify({ name, description, policy: { regoContent } }),
+      body: JSON.stringify(formData),
     });
 
     setLoading(false);

--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -50,9 +50,7 @@ const PolicyForm = ({
 
   const [name, setName] = useState(policy.name || "");
   const [description, setDescription] = useState(policy.description || "");
-  const [regoContent, setRegoContent] = useState(
-    policy?.policy?.regoContent || ""
-  );
+  const [regoContent, setRegoContent] = useState(policy.regoContent || "");
 
   const { isValid, validateField, errors } = useFormValidation(schema);
 

--- a/pages/api/occurrences.js
+++ b/pages/api/occurrences.js
@@ -15,8 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import fetch from "node-fetch";
-import { getRodeUrl } from "./utils/api-utils";
+import { get, getRodeUrl } from "./utils/api-utils";
 import { mapOccurrencesToSections } from "./utils/occurrence-utils";
 
 export default async (req, res) => {
@@ -30,7 +29,7 @@ export default async (req, res) => {
 
   try {
     const resourceUri = req.query.resourceUri;
-    const response = await fetch(
+    const response = await get(
       `${rodeUrl}/v1alpha1/versioned-resource-occurrences?resourceUri=${encodeURIComponent(
         resourceUri
       )}&fetchRelatedNotes=true&pageSize=1000`

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -15,11 +15,8 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import fetch from "node-fetch";
-import { getRodeUrl } from "./utils/api-utils";
+import { get, getRodeUrl, post } from "./utils/api-utils";
 import { mapToApiModel, mapToClientModel } from "./utils/policy-utils";
-
-// TODO: create fetch utils to handle stringifying and parsing bodies
 
 const ALLOWED_METHODS = ["GET", "POST"];
 
@@ -47,7 +44,7 @@ export default async (req, res) => {
       if (req.query.pageToken) {
         filter.pageToken = req.query.pageToken;
       }
-      const response = await fetch(
+      const response = await get(
         `${rodeUrl}/v1alpha1/policies?${new URLSearchParams(filter)}`
       );
 
@@ -80,10 +77,7 @@ export default async (req, res) => {
     try {
       const postBody = mapToApiModel(JSON.parse(req.body));
 
-      const response = await fetch(`${rodeUrl}/v1alpha1/policies`, {
-        method: "POST",
-        body: JSON.stringify(postBody),
-      });
+      const response = await post(`${rodeUrl}/v1alpha1/policies`, postBody);
 
       if (!response.ok) {
         console.error(`Unsuccessful response from Rode: ${response.status}`);

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -56,12 +56,14 @@ export default async (req, res) => {
       }
 
       const listPoliciesResponse = await response.json();
-      const policies = listPoliciesResponse.policies.map(({ id, name, description, policy }) => ({
-        id,
-        name: name,
-        description: description,
-        regoContent: policy.regoContent,
-      }));
+      const policies = listPoliciesResponse.policies.map(
+        ({ id, name, description, policy }) => ({
+          id,
+          name: name,
+          description: description,
+          regoContent: policy.regoContent,
+        })
+      );
 
       res.status(StatusCodes.OK).json({
         data: policies,

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -56,10 +56,10 @@ export default async (req, res) => {
       }
 
       const listPoliciesResponse = await response.json();
-      const policies = listPoliciesResponse.policies.map(({ id, policy }) => ({
+      const policies = listPoliciesResponse.policies.map(({ id, name, description, policy }) => ({
         id,
-        name: policy.name,
-        description: policy.description,
+        name: name,
+        description: description,
         regoContent: policy.regoContent,
       }));
 

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -18,6 +18,8 @@ import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import fetch from "node-fetch";
 import { getRodeUrl } from "./utils/api-utils";
 
+// TODO: create mapper for policies so changes in data model don't break everything
+
 const ALLOWED_METHODS = ["GET", "POST"];
 
 export default async (req, res) => {
@@ -112,8 +114,8 @@ export default async (req, res) => {
       const createPolicyResponse = await response.json();
       const policy = {
         id: createPolicyResponse.id,
-        name: createPolicyResponse.policy.name,
-        description: createPolicyResponse.policy.description,
+        name: createPolicyResponse.name,
+        description: createPolicyResponse.description,
         regoContent: createPolicyResponse.policy.regoContent,
       };
 

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -75,7 +75,7 @@ export default async (req, res) => {
 
   if (req.method === "POST") {
     try {
-      const postBody = mapToApiModel(req.body);
+      const postBody = mapToApiModel(req);
 
       const response = await post(`${rodeUrl}/v1alpha1/policies`, postBody);
 

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -75,7 +75,7 @@ export default async (req, res) => {
 
   if (req.method === "POST") {
     try {
-      const postBody = mapToApiModel(JSON.parse(req.body));
+      const postBody = mapToApiModel(req.body);
 
       const response = await post(`${rodeUrl}/v1alpha1/policies`, postBody);
 

--- a/pages/api/policies/[id].js
+++ b/pages/api/policies/[id].js
@@ -47,10 +47,11 @@ export default async (req, res) => {
       }
 
       const getPolicyResponse = await response.json();
+
       const policy = {
         id,
-        name: getPolicyResponse.policy.name,
-        description: getPolicyResponse.policy.description,
+        name: getPolicyResponse.name,
+        description: getPolicyResponse.description,
         regoContent: getPolicyResponse.policy.regoContent,
       };
 
@@ -99,8 +100,8 @@ export default async (req, res) => {
 
       const policy = {
         id,
-        name: updatePolicyResponse.policy.name,
-        description: updatePolicyResponse.policy.description,
+        name: updatePolicyResponse.name,
+        description: updatePolicyResponse.description,
         regoContent: updatePolicyResponse.policy.regoContent,
       };
 

--- a/pages/api/policies/[id].js
+++ b/pages/api/policies/[id].js
@@ -64,7 +64,7 @@ export default async (req, res) => {
     try {
       const { id } = req.query;
 
-      const updateBody = mapToApiModel(JSON.parse(req.body));
+      const updateBody = mapToApiModel(req.body);
 
       const response = await patch(
         `${rodeUrl}/v1alpha1/policies/${id}`,

--- a/pages/api/policies/[id].js
+++ b/pages/api/policies/[id].js
@@ -48,7 +48,7 @@ export default async (req, res) => {
 
       const getPolicyResponse = await response.json();
 
-      const policy = mapToClientModel({ ...getPolicyResponse, id });
+      const policy = mapToClientModel(getPolicyResponse);
 
       res.status(StatusCodes.OK).json(policy);
     } catch (error) {
@@ -95,7 +95,7 @@ export default async (req, res) => {
 
       const updatePolicyResponse = await response.json();
 
-      const policy = mapToClientModel({ ...updatePolicyResponse, id });
+      const policy = mapToClientModel(updatePolicyResponse);
 
       res.status(StatusCodes.OK).json(policy);
     } catch (error) {

--- a/pages/api/policies/[id].js
+++ b/pages/api/policies/[id].js
@@ -15,8 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import fetch from "node-fetch";
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { del, get, getRodeUrl, patch } from "pages/api/utils/api-utils";
 import { mapToApiModel, mapToClientModel } from "pages/api/utils/policy-utils";
 
 const ALLOWED_METHODS = ["GET", "PATCH", "DELETE"];
@@ -34,7 +33,7 @@ export default async (req, res) => {
     try {
       const { id } = req.query;
 
-      const response = await fetch(`${rodeUrl}/v1alpha1/policies/${id}`);
+      const response = await get(`${rodeUrl}/v1alpha1/policies/${id}`);
 
       if (response.status === StatusCodes.NOT_FOUND) {
         return res.status(StatusCodes.OK).send(null);
@@ -67,10 +66,10 @@ export default async (req, res) => {
 
       const updateBody = mapToApiModel(JSON.parse(req.body));
 
-      const response = await fetch(`${rodeUrl}/v1alpha1/policies/${id}`, {
-        method: "PATCH",
-        body: JSON.stringify(updateBody),
-      });
+      const response = await patch(
+        `${rodeUrl}/v1alpha1/policies/${id}`,
+        updateBody
+      );
 
       if (!response.ok) {
         console.error(`Unsuccessful response from Rode: ${response.status}`);
@@ -112,9 +111,7 @@ export default async (req, res) => {
     try {
       const { id } = req.query;
 
-      const response = await fetch(`${rodeUrl}/v1alpha1/policies/${id}`, {
-        method: "DELETE",
-      });
+      const response = await del(`${rodeUrl}/v1alpha1/policies/${id}`);
 
       if (!response.ok) {
         console.error(`Unsuccessful response from Rode: ${response.status}`);

--- a/pages/api/policies/[id].js
+++ b/pages/api/policies/[id].js
@@ -64,7 +64,7 @@ export default async (req, res) => {
     try {
       const { id } = req.query;
 
-      const updateBody = mapToApiModel(req.body);
+      const updateBody = mapToApiModel(req);
 
       const response = await patch(
         `${rodeUrl}/v1alpha1/policies/${id}`,

--- a/pages/api/policies/[id].js
+++ b/pages/api/policies/[id].js
@@ -17,6 +17,7 @@
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import fetch from "node-fetch";
 import { getRodeUrl } from "pages/api/utils/api-utils";
+import { mapToApiModel, mapToClientModel } from "pages/api/utils/policy-utils";
 
 const ALLOWED_METHODS = ["GET", "PATCH", "DELETE"];
 
@@ -48,12 +49,7 @@ export default async (req, res) => {
 
       const getPolicyResponse = await response.json();
 
-      const policy = {
-        id,
-        name: getPolicyResponse.name,
-        description: getPolicyResponse.description,
-        regoContent: getPolicyResponse.policy.regoContent,
-      };
+      const policy = mapToClientModel({ ...getPolicyResponse, id });
 
       res.status(StatusCodes.OK).json(policy);
     } catch (error) {
@@ -69,9 +65,11 @@ export default async (req, res) => {
     try {
       const { id } = req.query;
 
+      const updateBody = mapToApiModel(JSON.parse(req.body));
+
       const response = await fetch(`${rodeUrl}/v1alpha1/policies/${id}`, {
         method: "PATCH",
-        body: req.body,
+        body: JSON.stringify(updateBody),
       });
 
       if (!response.ok) {
@@ -98,12 +96,7 @@ export default async (req, res) => {
 
       const updatePolicyResponse = await response.json();
 
-      const policy = {
-        id,
-        name: updatePolicyResponse.name,
-        description: updatePolicyResponse.description,
-        regoContent: updatePolicyResponse.policy.regoContent,
-      };
+      const policy = mapToClientModel({ ...updatePolicyResponse, id });
 
       res.status(StatusCodes.OK).json(policy);
     } catch (error) {

--- a/pages/api/policies/[id]/attest.js
+++ b/pages/api/policies/[id]/attest.js
@@ -15,8 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import fetch from "node-fetch";
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { getRodeUrl, post } from "pages/api/utils/api-utils";
 
 const ALLOWED_METHODS = ["POST"];
 
@@ -33,10 +32,10 @@ export default async (req, res) => {
     const { id } = req.query;
     const requestBody = req.body;
 
-    const response = await fetch(`${rodeUrl}/v1alpha1/policies/${id}:attest`, {
-      method: "POST",
-      body: requestBody,
-    });
+    const response = await post(
+      `${rodeUrl}/v1alpha1/policies/${id}:attest`,
+      requestBody
+    );
 
     if (!response.ok) {
       console.error(`Unsuccessful response from Rode: ${response.status}`);

--- a/pages/api/policies/validate.js
+++ b/pages/api/policies/validate.js
@@ -15,8 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import fetch from "node-fetch";
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { getRodeUrl, post } from "pages/api/utils/api-utils";
 
 const ALLOWED_METHODS = ["POST"];
 
@@ -32,10 +31,10 @@ export default async (req, res) => {
   try {
     const policy = req.body;
 
-    const response = await fetch(`${rodeUrl}/v1alpha1/policies:validate`, {
-      method: "POST",
-      body: policy,
-    });
+    const response = await post(
+      `${rodeUrl}/v1alpha1/policies:validate`,
+      policy
+    );
 
     if (!response.ok) {
       console.error(`Unsuccessful response from Rode: ${response.status}`);

--- a/pages/api/resource-versions.js
+++ b/pages/api/resource-versions.js
@@ -15,8 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import fetch from "node-fetch";
-import { getRodeUrl } from "./utils/api-utils";
+import { get, getRodeUrl } from "./utils/api-utils";
 
 export default async (req, res) => {
   if (req.method !== "GET") {
@@ -49,7 +48,7 @@ export default async (req, res) => {
     if (req.query.pageToken) {
       params.pageToken = req.query.pageToken;
     }
-    const response = await fetch(
+    const response = await get(
       `${rodeUrl}/v1alpha1/generic-resource-versions?${new URLSearchParams(
         params
       )}`

--- a/pages/api/resources.js
+++ b/pages/api/resources.js
@@ -15,8 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import fetch from "node-fetch";
-import { getRodeUrl } from "./utils/api-utils";
+import { get, getRodeUrl } from "./utils/api-utils";
 
 export default async (req, res) => {
   if (req.method !== "GET") {
@@ -58,7 +57,7 @@ export default async (req, res) => {
       filter.pageToken = req.query.pageToken;
     }
 
-    const response = await fetch(
+    const response = await get(
       `${rodeUrl}/v1alpha1/generic-resources?${new URLSearchParams(filter)}`
     );
 

--- a/pages/api/utils/api-utils.js
+++ b/pages/api/utils/api-utils.js
@@ -25,7 +25,7 @@ const fetch = (endpoint, method, body) => {
   };
 
   if (body) {
-    options.body = JSON.stringify(body);
+    options.body = typeof body === "object" ? JSON.stringify(body) : body;
   }
 
   return nodeFetch(endpoint, options);

--- a/pages/api/utils/api-utils.js
+++ b/pages/api/utils/api-utils.js
@@ -14,5 +14,28 @@
  * limitations under the License.
  */
 
+import * as nodeFetch from "node-fetch";
+
 export const getRodeUrl = () =>
   process.env.RODE_URL || "http://localhost:50051";
+
+// TODO: test this
+const fetch = (endpoint, method, body) => {
+  const options = {
+    method,
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  return nodeFetch(endpoint, options);
+};
+
+export const post = (endpoint, body) => fetch(endpoint, "POST", body);
+
+export const patch = (endpoint, body) => fetch(endpoint, "PATCH", body);
+
+export const get = (endpoint) => fetch(endpoint, "GET");
+
+export const del = (endpoint) => fetch(endpoint, "DELETE");

--- a/pages/api/utils/api-utils.js
+++ b/pages/api/utils/api-utils.js
@@ -19,7 +19,6 @@ import * as nodeFetch from "node-fetch";
 export const getRodeUrl = () =>
   process.env.RODE_URL || "http://localhost:50051";
 
-// TODO: test this
 const fetch = (endpoint, method, body) => {
   const options = {
     method,

--- a/pages/api/utils/policy-utils.js
+++ b/pages/api/utils/policy-utils.js
@@ -15,20 +15,32 @@
  */
 
 export const mapToClientModel = (policyResponse) => {
+  let formattedResponse = policyResponse;
+
+  if (typeof policyResponse === "string") {
+    formattedResponse = JSON.parse(policyResponse);
+  }
+
   return {
-    id: policyResponse.id,
-    name: policyResponse.name,
-    description: policyResponse.description,
-    regoContent: policyResponse.policy.regoContent,
+    id: formattedResponse.id,
+    name: formattedResponse.name,
+    description: formattedResponse.description,
+    regoContent: formattedResponse.policy.regoContent,
   };
 };
 
 export const mapToApiModel = (requestBody) => {
+  let formattedRequest = requestBody;
+
+  if (typeof requestBody === "string") {
+    formattedRequest = JSON.parse(requestBody);
+  }
+
   return {
-    name: requestBody.name,
-    description: requestBody.description,
+    name: formattedRequest.name,
+    description: formattedRequest.description,
     policy: {
-      regoContent: requestBody.regoContent,
+      regoContent: formattedRequest.regoContent,
     },
   };
 };

--- a/pages/api/utils/policy-utils.js
+++ b/pages/api/utils/policy-utils.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: test this
+
+export const mapToClientModel = (policy) => {
+  return {
+    id: policy.id,
+    name: policy.name,
+    description: policy.description,
+    regoContent: policy.policy.regoContent,
+  };
+};
+
+export const mapToApiModel = (policy) => {
+  return {
+    name: policy.name,
+    description: policy.description,
+    policy: {
+      regoContent: policy.regoContent,
+    },
+  };
+};

--- a/pages/api/utils/policy-utils.js
+++ b/pages/api/utils/policy-utils.js
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-export const mapToClientModel = (policy) => {
+export const mapToClientModel = (policyResponse) => {
   return {
-    id: policy.id,
-    name: policy.name,
-    description: policy.description,
-    regoContent: policy.policy.regoContent,
+    id: policyResponse.id,
+    name: policyResponse.name,
+    description: policyResponse.description,
+    regoContent: policyResponse.policy.regoContent,
   };
 };
 
-export const mapToApiModel = (policy) => {
+export const mapToApiModel = (requestBody) => {
   return {
-    name: policy.name,
-    description: policy.description,
+    name: requestBody.name,
+    description: requestBody.description,
     policy: {
-      regoContent: policy.regoContent,
+      regoContent: requestBody.regoContent,
     },
   };
 };

--- a/pages/api/utils/policy-utils.js
+++ b/pages/api/utils/policy-utils.js
@@ -26,13 +26,6 @@ export const mapToClientModel = (policyResponse) => {
 export const mapToApiModel = (request) => {
   let formattedRequest = request.body;
 
-  if (
-    typeof request.body === "string" &&
-    request.headers["content-type"] === "application/json"
-  ) {
-    formattedRequest = JSON.parse(request.body);
-  }
-
   return {
     name: formattedRequest.name,
     description: formattedRequest.description,

--- a/pages/api/utils/policy-utils.js
+++ b/pages/api/utils/policy-utils.js
@@ -15,17 +15,11 @@
  */
 
 export const mapToClientModel = (policyResponse) => {
-  let formattedResponse = policyResponse;
-
-  if (typeof policyResponse === "string") {
-    formattedResponse = JSON.parse(policyResponse);
-  }
-
   return {
-    id: formattedResponse.id,
-    name: formattedResponse.name,
-    description: formattedResponse.description,
-    regoContent: formattedResponse.policy.regoContent,
+    id: policyResponse.id,
+    name: policyResponse.name,
+    description: policyResponse.description,
+    regoContent: policyResponse.policy.regoContent,
   };
 };
 

--- a/pages/api/utils/policy-utils.js
+++ b/pages/api/utils/policy-utils.js
@@ -23,11 +23,14 @@ export const mapToClientModel = (policyResponse) => {
   };
 };
 
-export const mapToApiModel = (requestBody) => {
-  let formattedRequest = requestBody;
+export const mapToApiModel = (request) => {
+  let formattedRequest = request.body;
 
-  if (typeof requestBody === "string") {
-    formattedRequest = JSON.parse(requestBody);
+  if (
+    typeof request.body === "string" &&
+    request.headers["content-type"] === "application/json"
+  ) {
+    formattedRequest = JSON.parse(request.body);
   }
 
   return {

--- a/pages/api/utils/policy-utils.js
+++ b/pages/api/utils/policy-utils.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// TODO: test this
-
 export const mapToClientModel = (policy) => {
   return {
     id: policy.id,

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -48,6 +48,9 @@ const PolicyPlayground = () => {
       {
         method: "POST",
         body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json'
+        }
       }
     );
 

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -49,8 +49,8 @@ const PolicyPlayground = () => {
         method: "POST",
         body: JSON.stringify(requestBody),
         headers: {
-          'Content-Type': 'application/json'
-        }
+          "Content-Type": "application/json",
+        },
       }
     );
 

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -29,7 +29,6 @@ import { policyActions } from "reducers/policies";
 import PageHeader from "components/layout/PageHeader";
 import Code from "components/Code";
 
-// TODO: e2e test updates
 const Policy = () => {
   const router = useRouter();
   const { theme } = useTheme();

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -29,8 +29,6 @@ import { policyActions } from "reducers/policies";
 import PageHeader from "components/layout/PageHeader";
 import Code from "components/Code";
 
-// TODO: creating a policy and navigating to policy page does not show correct information
-
 const Policy = () => {
   const router = useRouter();
   const { theme } = useTheme();

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -29,6 +29,7 @@ import { policyActions } from "reducers/policies";
 import PageHeader from "components/layout/PageHeader";
 import Code from "components/Code";
 
+// TODO: e2e test updates
 const Policy = () => {
   const router = useRouter();
   const { theme } = useTheme();

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -29,6 +29,8 @@ import { policyActions } from "reducers/policies";
 import PageHeader from "components/layout/PageHeader";
 import Code from "components/Code";
 
+// TODO: creating a policy and navigating to policy page does not show correct information
+
 const Policy = () => {
   const router = useRouter();
   const { theme } = useTheme();

--- a/pages/policies/new.js
+++ b/pages/policies/new.js
@@ -25,7 +25,7 @@ const NewPolicy = () => {
       endpoint={"/api/policies"}
       verb={"create"}
       submitButtonText={"Save Policy"}
-      policy={{ policy: { regoContent: EXAMPLE_POLICY } }}
+      policy={{ regoContent: EXAMPLE_POLICY }}
     />
   );
 };

--- a/pages/policies/new.js
+++ b/pages/policies/new.js
@@ -25,7 +25,7 @@ const NewPolicy = () => {
       endpoint={"/api/policies"}
       verb={"create"}
       submitButtonText={"Save Policy"}
-      policy={{ regoContent: EXAMPLE_POLICY }}
+      policy={{ policy: { regoContent: EXAMPLE_POLICY } }}
     />
   );
 };

--- a/test/components/policies/PolicyForm.spec.js
+++ b/test/components/policies/PolicyForm.spec.js
@@ -151,6 +151,9 @@ describe("Policy Form", () => {
           body: JSON.stringify({
             policy: regoContent,
           }),
+          headers: {
+            "Content-Type": "application/json",
+          },
         });
     });
 

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -18,6 +18,7 @@ import fetch from "node-fetch";
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policies";
 import { getRodeUrl } from "pages/api/utils/api-utils";
+import { mapToApiModel } from "pages/api/utils/policy-utils";
 
 jest.mock("node-fetch");
 jest.mock("pages/api/utils/api-utils");
@@ -222,7 +223,7 @@ describe("/api/policies", () => {
       };
       request = {
         method: "POST",
-        body: formData,
+        body: JSON.stringify(formData),
       };
 
       createdPolicy = {
@@ -249,7 +250,7 @@ describe("/api/policies", () => {
         expect(fetch)
           .toHaveBeenCalledTimes(1)
           .toHaveBeenCalledWith("http://localhost:50051/v1alpha1/policies", {
-            body: formData,
+            body: JSON.stringify(mapToApiModel(request.body)),
             method: "POST",
           });
       });

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import fetch from "node-fetch";
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policies";
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { get, post, getRodeUrl } from "pages/api/utils/api-utils";
 import { mapToApiModel } from "pages/api/utils/policy-utils";
 
 jest.mock("node-fetch");
@@ -105,7 +104,7 @@ describe("/api/policies", () => {
         }),
       };
 
-      fetch.mockResolvedValue(rodeResponse);
+      get.mockResolvedValue(rodeResponse);
     });
 
     describe("successful call to Rode", () => {
@@ -120,9 +119,7 @@ describe("/api/policies", () => {
 
         await handler(request, response);
 
-        expect(fetch)
-          .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith(expectedUrl);
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 
       it("should hit the Rode API when no filter is specified", async () => {
@@ -131,9 +128,7 @@ describe("/api/policies", () => {
         request.query.filter = null;
         await handler(request, response);
 
-        expect(fetch)
-          .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith(expectedUrl);
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 
       it("should pass the pageSize as a query param when a pageSize is specified", async () => {
@@ -145,9 +140,7 @@ describe("/api/policies", () => {
 
         request.query.pageSize = pageSize;
         await handler(request, response);
-        expect(fetch)
-          .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith(expectedUrl);
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 
       it("should pass the pageToken as a query param when a pageToken is specified", async () => {
@@ -159,9 +152,7 @@ describe("/api/policies", () => {
 
         request.query.pageToken = pageToken;
         await handler(request, response);
-        expect(fetch)
-          .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith(expectedUrl);
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 
       it("should return the mapped policies", async () => {
@@ -197,7 +188,7 @@ describe("/api/policies", () => {
       });
 
       it("should return an internal server error on a network or other fetch error", async () => {
-        fetch.mockRejectedValue(new Error());
+        get.mockRejectedValue(new Error());
 
         await handler(request, response);
 
@@ -240,19 +231,19 @@ describe("/api/policies", () => {
         json: jest.fn().mockResolvedValue(createdPolicy),
       };
 
-      fetch.mockResolvedValue(rodeResponse);
+      post.mockResolvedValue(rodeResponse);
     });
 
     describe("successful call to Rode", () => {
       it("should hit the Rode API", async () => {
         await handler(request, response);
 
-        expect(fetch)
+        expect(post)
           .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith("http://localhost:50051/v1alpha1/policies", {
-            body: JSON.stringify(mapToApiModel(request.body)),
-            method: "POST",
-          });
+          .toHaveBeenCalledWith(
+            "http://localhost:50051/v1alpha1/policies",
+            mapToApiModel(request.body)
+          );
       });
 
       it("should return the mapped created policy", async () => {
@@ -327,7 +318,7 @@ describe("/api/policies", () => {
       });
 
       it("should return an internal server error on a network or other fetch error", async () => {
-        fetch.mockRejectedValue(new Error());
+        post.mockRejectedValue(new Error());
 
         await handler(request, response);
 

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -227,9 +227,9 @@ describe("/api/policies", () => {
 
       createdPolicy = {
         id: chance.guid(),
+        name: chance.string(),
+        description: chance.sentence(),
         policy: {
-          name: chance.string(),
-          description: chance.sentence(),
           regoContent: chance.string(),
         },
       };
@@ -263,8 +263,8 @@ describe("/api/policies", () => {
 
         expect(response.json).toHaveBeenCalledTimes(1).toHaveBeenCalledWith({
           id: createdPolicy.id,
-          name: createdPolicy.policy.name,
-          description: createdPolicy.policy.description,
+          name: createdPolicy.name,
+          description: createdPolicy.description,
           regoContent: createdPolicy.policy.regoContent,
         });
       });

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -164,12 +164,14 @@ describe("/api/policies", () => {
       });
 
       it("should return the mapped policies", async () => {
-        const expectedPolicies = allPolicies.map(({ id, name, description, policy }) => ({
-          id,
-          name: name,
-          description: description,
-          regoContent: policy.regoContent,
-        }));
+        const expectedPolicies = allPolicies.map(
+          ({ id, name, description, policy }) => ({
+            id,
+            name: name,
+            description: description,
+            regoContent: policy.regoContent,
+          })
+        );
 
         await handler(request, response);
 

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -215,6 +215,9 @@ describe("/api/policies", () => {
       request = {
         method: "POST",
         body: JSON.stringify(formData),
+        headers: {
+          "Content-Type": "application/json",
+        },
       };
 
       createdPolicy = {
@@ -242,7 +245,7 @@ describe("/api/policies", () => {
           .toHaveBeenCalledTimes(1)
           .toHaveBeenCalledWith(
             "http://localhost:50051/v1alpha1/policies",
-            mapToApiModel(request.body)
+            mapToApiModel(request)
           );
       });
 

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -87,9 +87,9 @@ describe("/api/policies", () => {
         () => ({
           [chance.word()]: chance.word(),
           id: chance.guid(),
+          name: chance.name(),
+          description: chance.sentence(),
           policy: {
-            name: chance.name(),
-            description: chance.sentence(),
             regoContent: chance.string(),
           },
         }),
@@ -164,10 +164,10 @@ describe("/api/policies", () => {
       });
 
       it("should return the mapped policies", async () => {
-        const expectedPolicies = allPolicies.map(({ id, policy }) => ({
+        const expectedPolicies = allPolicies.map(({ id, name, description, policy }) => ({
           id,
-          name: policy.name,
-          description: policy.description,
+          name: name,
+          description: description,
           regoContent: policy.regoContent,
         }));
 

--- a/test/pages/api/policies/[id].spec.js
+++ b/test/pages/api/policies/[id].spec.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import fetch from "node-fetch";
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policies/[id]";
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { getRodeUrl, get, patch, del } from "pages/api/utils/api-utils";
 import { mapToApiModel } from "pages/api/utils/policy-utils";
 
 jest.mock("node-fetch");
@@ -61,7 +60,7 @@ describe("/api/policies/[id]", () => {
       }),
     };
 
-    fetch.mockResolvedValue(rodeResponse);
+    get.mockResolvedValue(rodeResponse);
   });
 
   afterEach(() => {
@@ -87,6 +86,8 @@ describe("/api/policies/[id]", () => {
   describe("GET", () => {
     beforeEach(() => {
       request.method = "GET";
+
+      get.mockResolvedValue(rodeResponse);
     });
 
     describe("successful call to Rode", () => {
@@ -104,7 +105,7 @@ describe("/api/policies/[id]", () => {
       it("should hit the Rode API", async () => {
         await handler(request, response);
 
-        expect(fetch)
+        expect(get)
           .toHaveBeenCalledTimes(1)
           .toHaveBeenCalledWith(`${expectedRodeUrl}/v1alpha1/policies/${id}`);
       });
@@ -158,7 +159,7 @@ describe("/api/policies/[id]", () => {
       });
 
       it("should return an internal server error on a network or other fetch error", async () => {
-        fetch.mockRejectedValue(new Error());
+        get.mockRejectedValue(new Error());
 
         await handler(request, response);
 
@@ -179,6 +180,7 @@ describe("/api/policies/[id]", () => {
     beforeEach(() => {
       request.method = "PATCH";
       request.body = JSON.stringify(foundPolicy);
+      patch.mockResolvedValue(rodeResponse);
     });
 
     describe("successful call to Rode", () => {
@@ -196,12 +198,12 @@ describe("/api/policies/[id]", () => {
       it("should hit the Rode API", async () => {
         await handler(request, response);
 
-        expect(fetch)
+        expect(patch)
           .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith(`${expectedRodeUrl}/v1alpha1/policies/${id}`, {
-            method: "PATCH",
-            body: JSON.stringify(mapToApiModel(JSON.parse(request.body))),
-          });
+          .toHaveBeenCalledWith(
+            `${expectedRodeUrl}/v1alpha1/policies/${id}`,
+            mapToApiModel(JSON.parse(request.body))
+          );
       });
 
       it("should return the updated policy", async () => {
@@ -286,7 +288,7 @@ describe("/api/policies/[id]", () => {
       });
 
       it("should return an internal server error on a network or other fetch error", async () => {
-        fetch.mockRejectedValue(new Error());
+        patch.mockRejectedValue(new Error());
 
         await handler(request, response);
 
@@ -314,6 +316,7 @@ describe("/api/policies/[id]", () => {
       beforeEach(() => {
         rodeUrlEnv = process.env.RODE_URL;
         delete process.env.RODE_URL;
+        del.mockResolvedValue(rodeResponse);
       });
 
       afterEach(() => {
@@ -323,11 +326,9 @@ describe("/api/policies/[id]", () => {
       it("should hit the Rode API", async () => {
         await handler(request, response);
 
-        expect(fetch)
+        expect(del)
           .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith(`${expectedRodeUrl}/v1alpha1/policies/${id}`, {
-            method: "DELETE",
-          });
+          .toHaveBeenCalledWith(`${expectedRodeUrl}/v1alpha1/policies/${id}`);
       });
 
       it("should return null if the delete was successful", async () => {
@@ -356,6 +357,7 @@ describe("/api/policies/[id]", () => {
 
       it("should return an internal server error on a non-200 response from Rode", async () => {
         rodeResponse.ok = false;
+        del.mockResolvedValue(rodeResponse);
 
         await handler(request, response);
 
@@ -363,7 +365,7 @@ describe("/api/policies/[id]", () => {
       });
 
       it("should return an internal server error on a network or other fetch error", async () => {
-        fetch.mockRejectedValue(new Error());
+        del.mockRejectedValue(new Error());
 
         await handler(request, response);
 

--- a/test/pages/api/policies/[id].spec.js
+++ b/test/pages/api/policies/[id].spec.js
@@ -91,17 +91,6 @@ describe("/api/policies/[id]", () => {
     });
 
     describe("successful call to Rode", () => {
-      let rodeUrlEnv;
-
-      beforeEach(() => {
-        rodeUrlEnv = process.env.RODE_URL;
-        delete process.env.RODE_URL;
-      });
-
-      afterEach(() => {
-        process.env.RODE_URL = rodeUrlEnv;
-      });
-
       it("should hit the Rode API", async () => {
         await handler(request, response);
 
@@ -184,17 +173,6 @@ describe("/api/policies/[id]", () => {
     });
 
     describe("successful call to Rode", () => {
-      let rodeUrlEnv;
-
-      beforeEach(() => {
-        rodeUrlEnv = process.env.RODE_URL;
-        delete process.env.RODE_URL;
-      });
-
-      afterEach(() => {
-        process.env.RODE_URL = rodeUrlEnv;
-      });
-
       it("should hit the Rode API", async () => {
         await handler(request, response);
 

--- a/test/pages/api/policies/[id].spec.js
+++ b/test/pages/api/policies/[id].spec.js
@@ -18,6 +18,7 @@ import fetch from "node-fetch";
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policies/[id]";
 import { getRodeUrl } from "pages/api/utils/api-utils";
+import { mapToApiModel } from "pages/api/utils/policy-utils";
 
 jest.mock("node-fetch");
 jest.mock("pages/api/utils/api-utils");
@@ -177,7 +178,7 @@ describe("/api/policies/[id]", () => {
   describe("PATCH", () => {
     beforeEach(() => {
       request.method = "PATCH";
-      request.body = foundPolicy;
+      request.body = JSON.stringify(foundPolicy);
     });
 
     describe("successful call to Rode", () => {
@@ -199,7 +200,7 @@ describe("/api/policies/[id]", () => {
           .toHaveBeenCalledTimes(1)
           .toHaveBeenCalledWith(`${expectedRodeUrl}/v1alpha1/policies/${id}`, {
             method: "PATCH",
-            body: request.body,
+            body: JSON.stringify(mapToApiModel(JSON.parse(request.body))),
           });
       });
 

--- a/test/pages/api/policies/[id].spec.js
+++ b/test/pages/api/policies/[id].spec.js
@@ -45,14 +45,18 @@ describe("/api/policies/[id]", () => {
     foundPolicy = {
       name: chance.string(),
       description: chance.string(),
-      regoContent: chance.string(),
+      policy: {
+        version: chance.d4(),
+        message: chance.string(),
+        regoContent: chance.string(),
+      },
     };
 
     rodeResponse = {
       ok: true,
       json: jest.fn().mockResolvedValue({
         id,
-        policy: foundPolicy,
+        ...foundPolicy,
       }),
     };
 
@@ -115,7 +119,7 @@ describe("/api/policies/[id]", () => {
           id,
           name: foundPolicy.name,
           description: foundPolicy.description,
-          regoContent: foundPolicy.regoContent,
+          regoContent: foundPolicy.policy.regoContent,
         });
       });
 
@@ -210,7 +214,7 @@ describe("/api/policies/[id]", () => {
           id,
           name: foundPolicy.name,
           description: foundPolicy.description,
-          regoContent: foundPolicy.regoContent,
+          regoContent: foundPolicy.policy.regoContent,
         });
       });
     });

--- a/test/pages/api/policies/[id].spec.js
+++ b/test/pages/api/policies/[id].spec.js
@@ -43,6 +43,7 @@ describe("/api/policies/[id]", () => {
     };
 
     foundPolicy = {
+      id,
       name: chance.string(),
       description: chance.string(),
       policy: {

--- a/test/pages/api/policies/[id].spec.js
+++ b/test/pages/api/policies/[id].spec.js
@@ -170,6 +170,9 @@ describe("/api/policies/[id]", () => {
     beforeEach(() => {
       request.method = "PATCH";
       request.body = JSON.stringify(foundPolicy);
+      request.headers = {
+        "Content-Type": "application/json",
+      };
       patch.mockResolvedValue(rodeResponse);
     });
 
@@ -181,7 +184,7 @@ describe("/api/policies/[id]", () => {
           .toHaveBeenCalledTimes(1)
           .toHaveBeenCalledWith(
             `${expectedRodeUrl}/v1alpha1/policies/${id}`,
-            mapToApiModel(JSON.parse(request.body))
+            mapToApiModel(request)
           );
       });
 

--- a/test/pages/api/policies/[id]/attest.spec.js
+++ b/test/pages/api/policies/[id]/attest.spec.js
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import fetch from "node-fetch";
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policies/[id]/attest";
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { getRodeUrl, post } from "pages/api/utils/api-utils";
 
-jest.mock("node-fetch");
 jest.mock("pages/api/utils/api-utils");
 
 describe("/api/policies/[id]/attest", () => {
@@ -55,7 +53,7 @@ describe("/api/policies/[id]/attest", () => {
       json: jest.fn().mockResolvedValue(evalResponse),
     };
 
-    fetch.mockResolvedValue(rodeResponse);
+    post.mockResolvedValue(rodeResponse);
   });
 
   afterEach(() => {
@@ -83,14 +81,11 @@ describe("/api/policies/[id]/attest", () => {
       it("should hit the Rode API", async () => {
         await handler(request, response);
 
-        expect(fetch)
+        expect(post)
           .toHaveBeenCalledTimes(1)
           .toHaveBeenCalledWith(
             `${expectedRodeUrl}/v1alpha1/policies/${id}:attest`,
-            {
-              method: "POST",
-              body: request.body,
-            }
+            request.body
           );
       });
 
@@ -127,7 +122,7 @@ describe("/api/policies/[id]/attest", () => {
       });
 
       it("should return an internal server error on a network or other fetch error", async () => {
-        fetch.mockRejectedValue(new Error());
+        post.mockRejectedValue(new Error());
 
         await handler(request, response);
 

--- a/test/pages/api/policies/validate.spec.js
+++ b/test/pages/api/policies/validate.spec.js
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import fetch from "node-fetch";
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policies/validate";
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { getRodeUrl, post } from "pages/api/utils/api-utils";
 
-jest.mock("node-fetch");
 jest.mock("pages/api/utils/api-utils");
 
 describe("/api/policies/validate", () => {
@@ -48,7 +46,7 @@ describe("/api/policies/validate", () => {
       json: jest.fn().mockResolvedValue(validationResult),
     };
 
-    fetch.mockResolvedValue(rodeResponse);
+    post.mockResolvedValue(rodeResponse);
     getRodeUrl.mockReturnValue("http://localhost:50051");
   });
 
@@ -86,14 +84,11 @@ describe("/api/policies/validate", () => {
     it("should hit the Rode API", async () => {
       await handler(request, response);
 
-      expect(fetch)
+      expect(post)
         .toHaveBeenCalledTimes(1)
         .toHaveBeenCalledWith(
           "http://localhost:50051/v1alpha1/policies:validate",
-          {
-            body: request.body,
-            method: "POST",
-          }
+          request.body
         );
     });
 
@@ -191,7 +186,7 @@ describe("/api/policies/validate", () => {
     });
 
     it("should return an internal server error on a network or other fetch error", async () => {
-      fetch.mockRejectedValue(new Error());
+      post.mockRejectedValue(new Error());
 
       await handler(request, response);
 

--- a/test/pages/api/utils/api-utils.spec.js
+++ b/test/pages/api/utils/api-utils.spec.js
@@ -39,12 +39,14 @@ describe("api-utils", () => {
   });
 
   describe("post", () => {
+    let body, endpoint;
+
     it("should call fetch with the appropriate params", () => {
-      const body = {
+      body = {
         [chance.string()]: chance.string(),
       };
 
-      const endpoint = chance.url();
+      endpoint = chance.url();
 
       post(endpoint, body);
 
@@ -53,21 +55,44 @@ describe("api-utils", () => {
         body: JSON.stringify(body),
       });
     });
+
+    it("should pass the raw body if it is not an object", () => {
+      body = chance.string();
+      endpoint = chance.url();
+      post(endpoint, body);
+      expect(fetch).toHaveBeenCalledWith(endpoint, {
+        method: "POST",
+        body,
+      });
+    });
   });
 
   describe("patch", () => {
+    let body, endpoint;
     it("should call fetch with the appropriate params", () => {
-      const body = {
+      body = {
         [chance.string()]: chance.string(),
       };
 
-      const endpoint = chance.url();
+      endpoint = chance.url();
 
       patch(endpoint, body);
 
       expect(fetch).toHaveBeenCalledWith(endpoint, {
         method: "PATCH",
         body: JSON.stringify(body),
+      });
+    });
+
+    it("should pass the raw body if it is not an object", () => {
+      body = chance.string();
+      endpoint = chance.url();
+
+      patch(endpoint, body);
+
+      expect(fetch).toHaveBeenCalledWith(endpoint, {
+        method: "PATCH",
+        body,
       });
     });
   });

--- a/test/pages/api/utils/api-utils.spec.js
+++ b/test/pages/api/utils/api-utils.spec.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { getRodeUrl } from "pages/api/utils/api-utils";
+import { getRodeUrl, post, patch, get, del } from "pages/api/utils/api-utils";
+import fetch from "node-fetch";
+
+jest.mock("node-fetch");
 
 describe("api-utils", () => {
   describe("getRodeUrl", () => {
@@ -32,6 +35,64 @@ describe("api-utils", () => {
       const actual = getRodeUrl();
 
       expect(actual).toEqual("http://localhost:50051");
+    });
+  });
+
+  describe("post", () => {
+    it("should call fetch with the appropriate params", () => {
+      const body = {
+        [chance.string()]: chance.string(),
+      };
+
+      const endpoint = chance.url();
+
+      post(endpoint, body);
+
+      expect(fetch).toHaveBeenCalledWith(endpoint, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    });
+  });
+
+  describe("patch", () => {
+    it("should call fetch with the appropriate params", () => {
+      const body = {
+        [chance.string()]: chance.string(),
+      };
+
+      const endpoint = chance.url();
+
+      patch(endpoint, body);
+
+      expect(fetch).toHaveBeenCalledWith(endpoint, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      });
+    });
+  });
+
+  describe("get", () => {
+    it("should call fetch with the appropriate params", () => {
+      const endpoint = chance.url();
+
+      get(endpoint);
+
+      expect(fetch).toHaveBeenCalledWith(endpoint, {
+        method: "GET",
+      });
+    });
+  });
+
+  describe("del", () => {
+    it("should call fetch with the appropriate params", () => {
+      const endpoint = chance.url();
+
+      del(endpoint);
+
+      expect(fetch).toHaveBeenCalledWith(endpoint, {
+        method: "DELETE",
+      });
     });
   });
 });

--- a/test/pages/api/utils/policy-utils.spec.js
+++ b/test/pages/api/utils/policy-utils.spec.js
@@ -42,17 +42,6 @@ describe("policy-utils", () => {
         regoContent: unmappedPolicy.policy.regoContent,
       });
     });
-
-    it("should parse the data if the response is passed as a string", () => {
-      const actual = mapToClientModel(JSON.stringify(unmappedPolicy));
-
-      expect(actual).toEqual({
-        id: unmappedPolicy.id,
-        name: unmappedPolicy.name,
-        description: unmappedPolicy.description,
-        regoContent: unmappedPolicy.policy.regoContent,
-      });
-    });
   });
 
   describe("mapToApiModel", () => {

--- a/test/pages/api/utils/policy-utils.spec.js
+++ b/test/pages/api/utils/policy-utils.spec.js
@@ -71,21 +71,5 @@ describe("policy-utils", () => {
         },
       });
     });
-
-    it("should parse the data if the request is passed as a string but should be json", () => {
-      request.body = JSON.stringify(unmappedPolicy);
-      request.headers = {
-        "content-type": "application/json",
-      };
-      const actual = mapToApiModel(request);
-
-      expect(actual).toEqual({
-        name: unmappedPolicy.name,
-        description: unmappedPolicy.description,
-        policy: {
-          regoContent: unmappedPolicy.regoContent,
-        },
-      });
-    });
   });
 });

--- a/test/pages/api/utils/policy-utils.spec.js
+++ b/test/pages/api/utils/policy-utils.spec.js
@@ -45,7 +45,7 @@ describe("policy-utils", () => {
   });
 
   describe("mapToApiModel", () => {
-    let unmappedPolicy;
+    let unmappedPolicy, request;
 
     beforeEach(() => {
       unmappedPolicy = {
@@ -54,10 +54,14 @@ describe("policy-utils", () => {
         description: chance.string(),
         regoContent: chance.string(),
       };
+
+      request = {
+        body: unmappedPolicy,
+      };
     });
 
     it("should return the mapped policy matching the api model", () => {
-      const actual = mapToApiModel(unmappedPolicy);
+      const actual = mapToApiModel(request);
 
       expect(actual).toEqual({
         name: unmappedPolicy.name,
@@ -68,8 +72,12 @@ describe("policy-utils", () => {
       });
     });
 
-    it("should parse the data if the request is passed as a string", () => {
-      const actual = mapToApiModel(JSON.stringify(unmappedPolicy));
+    it("should parse the data if the request is passed as a string but should be json", () => {
+      request.body = JSON.stringify(unmappedPolicy);
+      request.headers = {
+        "content-type": "application/json",
+      };
+      const actual = mapToApiModel(request);
 
       expect(actual).toEqual({
         name: unmappedPolicy.name,

--- a/test/pages/api/utils/policy-utils.spec.js
+++ b/test/pages/api/utils/policy-utils.spec.js
@@ -18,8 +18,9 @@ import { mapToClientModel, mapToApiModel } from "pages/api/utils/policy-utils";
 
 describe("policy-utils", () => {
   describe("mapToClientModel", () => {
-    it("should return the mapped policy matching the client model", () => {
-      const unmapped = {
+    let unmappedPolicy;
+    beforeEach(() => {
+      unmappedPolicy = {
         [chance.string()]: chance.string(),
         id: chance.string(),
         name: chance.string(),
@@ -29,34 +30,63 @@ describe("policy-utils", () => {
           regoContent: chance.string(),
         },
       };
+    });
 
-      const actual = mapToClientModel(unmapped);
+    it("should return the mapped policy matching the client model", () => {
+      const actual = mapToClientModel(unmappedPolicy);
 
       expect(actual).toEqual({
-        id: unmapped.id,
-        name: unmapped.name,
-        description: unmapped.description,
-        regoContent: unmapped.policy.regoContent,
+        id: unmappedPolicy.id,
+        name: unmappedPolicy.name,
+        description: unmappedPolicy.description,
+        regoContent: unmappedPolicy.policy.regoContent,
+      });
+    });
+
+    it("should parse the data if the response is passed as a string", () => {
+      const actual = mapToClientModel(JSON.stringify(unmappedPolicy));
+
+      expect(actual).toEqual({
+        id: unmappedPolicy.id,
+        name: unmappedPolicy.name,
+        description: unmappedPolicy.description,
+        regoContent: unmappedPolicy.policy.regoContent,
       });
     });
   });
 
   describe("mapToApiModel", () => {
-    it("should return the mapped policy matching the api model", () => {
-      const unmapped = {
+    let unmappedPolicy;
+
+    beforeEach(() => {
+      unmappedPolicy = {
         [chance.string()]: chance.string(),
         name: chance.string(),
         description: chance.string(),
         regoContent: chance.string(),
       };
+    });
 
-      const actual = mapToApiModel(unmapped);
+    it("should return the mapped policy matching the api model", () => {
+      const actual = mapToApiModel(unmappedPolicy);
 
       expect(actual).toEqual({
-        name: unmapped.name,
-        description: unmapped.description,
+        name: unmappedPolicy.name,
+        description: unmappedPolicy.description,
         policy: {
-          regoContent: unmapped.regoContent,
+          regoContent: unmappedPolicy.regoContent,
+        },
+      });
+    });
+
+    it("should parse the data if the request is passed as a string", () => {
+      const actual = mapToApiModel(JSON.stringify(unmappedPolicy));
+
+      expect(actual).toEqual({
+        name: unmappedPolicy.name,
+        description: unmappedPolicy.description,
+        policy: {
+          regoContent: unmappedPolicy.regoContent,
         },
       });
     });

--- a/test/pages/api/utils/policy-utils.spec.js
+++ b/test/pages/api/utils/policy-utils.spec.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mapToClientModel, mapToApiModel } from "pages/api/utils/policy-utils";
+
+describe("policy-utils", () => {
+  describe("mapToClientModel", () => {
+    it("should return the mapped policy matching the client model", () => {
+      const unmapped = {
+        [chance.string()]: chance.string(),
+        id: chance.string(),
+        name: chance.string(),
+        description: chance.string(),
+        policy: {
+          [chance.string()]: chance.string(),
+          regoContent: chance.string(),
+        },
+      };
+
+      const actual = mapToClientModel(unmapped);
+
+      expect(actual).toEqual({
+        id: unmapped.id,
+        name: unmapped.name,
+        description: unmapped.description,
+        regoContent: unmapped.policy.regoContent,
+      });
+    });
+  });
+
+  describe("mapToApiModel", () => {
+    it("should return the mapped policy matching the api model", () => {
+      const unmapped = {
+        [chance.string()]: chance.string(),
+        name: chance.string(),
+        description: chance.string(),
+        regoContent: chance.string(),
+      };
+
+      const actual = mapToApiModel(unmapped);
+
+      expect(actual).toEqual({
+        name: unmapped.name,
+        description: unmapped.description,
+        policy: {
+          regoContent: unmapped.regoContent,
+        },
+      });
+    });
+  });
+});

--- a/test/pages/playground.spec.js
+++ b/test/pages/playground.spec.js
@@ -267,6 +267,9 @@ describe("PolicyPlayground", () => {
                 resourceUri:
                   policyState.evaluationResource.versionedResourceUri,
               }),
+              headers: {
+                'Content-Type': 'application/json'
+              }
             }
           );
 

--- a/test/pages/playground.spec.js
+++ b/test/pages/playground.spec.js
@@ -268,8 +268,8 @@ describe("PolicyPlayground", () => {
                   policyState.evaluationResource.versionedResourceUri,
               }),
               headers: {
-                'Content-Type': 'application/json'
-              }
+                "Content-Type": "application/json",
+              },
             }
           );
 

--- a/test/pages/policies/[id]/edit.spec.js
+++ b/test/pages/policies/[id]/edit.spec.js
@@ -264,17 +264,16 @@ describe("Edit Policy", () => {
     });
 
     it("should submit the form when filled out entirely", () => {
+      const formData = {
+        name: policy.name,
+        description: policy.description,
+        regoContent: policy.regoContent,
+      };
       expect(fetch)
         .toHaveBeenCalledTimes(1)
         .toHaveBeenCalledWith(`/api/policies/${policy.id}`, {
           method: "PATCH",
-          body: JSON.stringify({
-            name: policy.name,
-            description: policy.description,
-            policy: {
-              regoContent: policy.regoContent,
-            },
-          }),
+          body: JSON.stringify(formData),
         });
     });
 

--- a/test/pages/policies/[id]/edit.spec.js
+++ b/test/pages/policies/[id]/edit.spec.js
@@ -274,6 +274,9 @@ describe("Edit Policy", () => {
         .toHaveBeenCalledWith(`/api/policies/${policy.id}`, {
           method: "PATCH",
           body: JSON.stringify(formData),
+          headers: {
+            "Content-Type": "application/json",
+          },
         });
     });
 

--- a/test/pages/policies/[id]/edit.spec.js
+++ b/test/pages/policies/[id]/edit.spec.js
@@ -56,9 +56,7 @@ describe("Edit Policy", () => {
       id: router.query.id,
       name: chance.string(),
       description: chance.sentence(),
-      policy: {
-        regoContent: chance.string(),
-      },
+      regoContent: chance.string(),
     };
     dispatchMock = jest.fn();
     fetchResponse = {
@@ -117,9 +115,7 @@ describe("Edit Policy", () => {
     expect(screen.getByLabelText(/description/i)).toHaveValue(
       policy.description
     );
-    expect(screen.getByLabelText(/rego/i)).toHaveValue(
-      policy.policy.regoContent
-    );
+    expect(screen.getByLabelText(/rego/i)).toHaveValue(policy.regoContent);
   });
 
   it("should render the save button for the form", () => {
@@ -263,7 +259,7 @@ describe("Edit Policy", () => {
       expect(isValid).toHaveBeenCalledTimes(1).toHaveBeenCalledWith({
         name: policy.name,
         description: policy.description,
-        regoContent: policy.policy.regoContent,
+        regoContent: policy.regoContent,
       });
     });
 
@@ -276,7 +272,7 @@ describe("Edit Policy", () => {
             name: policy.name,
             description: policy.description,
             policy: {
-              regoContent: policy.policy.regoContent,
+              regoContent: policy.regoContent,
             },
           }),
         });

--- a/test/pages/policies/[id]/edit.spec.js
+++ b/test/pages/policies/[id]/edit.spec.js
@@ -56,7 +56,9 @@ describe("Edit Policy", () => {
       id: router.query.id,
       name: chance.string(),
       description: chance.sentence(),
-      regoContent: chance.string(),
+      policy: {
+        regoContent: chance.string(),
+      },
     };
     dispatchMock = jest.fn();
     fetchResponse = {
@@ -115,7 +117,9 @@ describe("Edit Policy", () => {
     expect(screen.getByLabelText(/description/i)).toHaveValue(
       policy.description
     );
-    expect(screen.getByLabelText(/rego/i)).toHaveValue(policy.regoContent);
+    expect(screen.getByLabelText(/rego/i)).toHaveValue(
+      policy.policy.regoContent
+    );
   });
 
   it("should render the save button for the form", () => {
@@ -259,7 +263,7 @@ describe("Edit Policy", () => {
       expect(isValid).toHaveBeenCalledTimes(1).toHaveBeenCalledWith({
         name: policy.name,
         description: policy.description,
-        regoContent: policy.regoContent,
+        regoContent: policy.policy.regoContent,
       });
     });
 
@@ -271,7 +275,9 @@ describe("Edit Policy", () => {
           body: JSON.stringify({
             name: policy.name,
             description: policy.description,
-            regoContent: policy.regoContent,
+            policy: {
+              regoContent: policy.policy.regoContent,
+            },
           }),
         });
     });

--- a/test/pages/policies/new.spec.js
+++ b/test/pages/policies/new.spec.js
@@ -119,6 +119,9 @@ describe("New Policy", () => {
         .toHaveBeenCalledWith("/api/policies", {
           method: "POST",
           body: JSON.stringify(formData),
+          headers: {
+            "Content-Type": "application/json",
+          },
         });
     });
 

--- a/test/pages/policies/new.spec.js
+++ b/test/pages/policies/new.spec.js
@@ -118,7 +118,11 @@ describe("New Policy", () => {
         .toHaveBeenCalledTimes(1)
         .toHaveBeenCalledWith("/api/policies", {
           method: "POST",
-          body: JSON.stringify(formData),
+          body: JSON.stringify({
+            name: formData.name,
+            description: formData.description,
+            policy: { regoContent: formData.regoContent },
+          }),
         });
     });
 

--- a/test/pages/policies/new.spec.js
+++ b/test/pages/policies/new.spec.js
@@ -118,11 +118,7 @@ describe("New Policy", () => {
         .toHaveBeenCalledTimes(1)
         .toHaveBeenCalledWith("/api/policies", {
           method: "POST",
-          body: JSON.stringify({
-            name: formData.name,
-            description: formData.description,
-            policy: { regoContent: formData.regoContent },
-          }),
+          body: JSON.stringify(formData),
         });
     });
 


### PR DESCRIPTION
Closes #112 

* consumes the updated policy model
* adds api call helpers to handle some of the formatting needed to send data
* adds mappers to isolate changes needed to update the policy model
* removes some unneeded tests and set-up

This is dependent on a new release of Rode. As of [v0.9.2](https://github.com/rode/rode/releases/tag/v0.9.2) the policy model is not yet updated for these changes.