### PR TITLE
Remove generic resource from code

### DIFF
--- a/components/playground/ResourceSearchAndResults.js
+++ b/components/playground/ResourceSearchAndResults.js
@@ -34,8 +34,8 @@ import { ICON_NAMES } from "utils/icon-utils";
 import { buildResourceQueryParams } from "utils/resource-utils";
 import useDebouncedValue from "hooks/useDebouncedValue";
 
-const ResourceSearchAndResults = ({ genericResource, onResourceSelect }) => {
-  const [resourceSearch, setResourceSearch] = useState(!!genericResource);
+const ResourceSearchAndResults = ({ selectedResource, onResourceSelect }) => {
+  const [resourceSearch, setResourceSearch] = useState(!!selectedResource);
   const [debounceDelay, setDebounceDelay] = useState(DEFAULT_DEBOUNCE_DELAY);
   const { state, dispatch } = useResources();
   const debouncedSearch = useDebouncedValue(state.searchTerm, debounceDelay);
@@ -83,7 +83,7 @@ const ResourceSearchAndResults = ({ genericResource, onResourceSelect }) => {
               <>
                 {data.map((result) => {
                   const { id, name, type } = result;
-                  const isCurrentResource = id === genericResource?.id;
+                  const isCurrentResource = id === selectedResource?.id;
 
                   return (
                     <div className={`${styles.searchCard}`} key={id}>
@@ -143,7 +143,7 @@ const ResourceSearchAndResults = ({ genericResource, onResourceSelect }) => {
 };
 
 ResourceSearchAndResults.propTypes = {
-  genericResource: PropTypes.object,
+  selectedResource: PropTypes.object,
   onResourceSelect: PropTypes.func.isRequired,
 };
 

--- a/components/playground/ResourceSelectionDrawer.js
+++ b/components/playground/ResourceSelectionDrawer.js
@@ -29,7 +29,10 @@ import { resourceActions } from "reducers/resources";
 const RESOURCE = "Resource";
 const VERSION = "Version";
 
-const ResourceSelectionDrawer = ({ setResource, clearEvaluation }) => {
+const ResourceSelectionDrawer = ({
+  setEvaluationResource,
+  clearEvaluation,
+}) => {
   const { dispatch } = useResources();
   const [genericResource, setGenericResource] = useState(null);
   const [resourceVersion, setResourceVersion] = useState(null);
@@ -53,7 +56,7 @@ const ResourceSelectionDrawer = ({ setResource, clearEvaluation }) => {
     clearEvaluation();
 
     if (genericResource && resourceVersion) {
-      setResource(resourceVersion);
+      setEvaluationResource(resourceVersion);
     }
   }, [genericResource, resourceVersion]);
 
@@ -125,7 +128,7 @@ const ResourceSelectionDrawer = ({ setResource, clearEvaluation }) => {
 };
 
 ResourceSelectionDrawer.propTypes = {
-  setResource: PropTypes.func.isRequired,
+  setEvaluationResource: PropTypes.func.isRequired,
   clearEvaluation: PropTypes.func.isRequired,
 };
 

--- a/components/playground/ResourceSelectionDrawer.js
+++ b/components/playground/ResourceSelectionDrawer.js
@@ -34,7 +34,7 @@ const ResourceSelectionDrawer = ({
   clearEvaluation,
 }) => {
   const { dispatch } = useResources();
-  const [genericResource, setGenericResource] = useState(null);
+  const [resource, setResource] = useState(null);
   const [resourceVersion, setResourceVersion] = useState(null);
   const [showDrawer, setShowDrawer] = useState(false);
   const [currentSection, setCurrentSection] = useState(RESOURCE);
@@ -55,10 +55,10 @@ const ResourceSelectionDrawer = ({
   useEffect(() => {
     clearEvaluation();
 
-    if (genericResource && resourceVersion) {
+    if (resource && resourceVersion) {
       setEvaluationResource(resourceVersion);
     }
-  }, [genericResource, resourceVersion]);
+  }, [resource, resourceVersion]);
 
   return (
     <>
@@ -67,7 +67,7 @@ const ResourceSelectionDrawer = ({
         buttonType="icon"
         onClick={() => {
           clearSearchTerms();
-          setGenericResource(null);
+          setResource(null);
           setResourceVersion(null);
           setCurrentSection(RESOURCE);
           setShowDrawer(true);
@@ -96,7 +96,7 @@ const ResourceSelectionDrawer = ({
             buttonType={"text"}
             onClick={openVersionSelection}
             label={"Version"}
-            disabled={!genericResource}
+            disabled={!resource}
             className={
               currentSection === VERSION
                 ? styles.activeNavigationButton
@@ -106,16 +106,16 @@ const ResourceSelectionDrawer = ({
         </div>
         {currentSection === RESOURCE && (
           <ResourceSearchAndResults
-            genericResource={genericResource}
+            selectedResource={resource}
             onResourceSelect={(resource) => {
-              setGenericResource(resource);
+              setResource(resource);
               openVersionSelection();
             }}
           />
         )}
         {currentSection === VERSION && (
           <ResourceVersionSearchAndResults
-            genericResource={genericResource}
+            selectedResource={resource}
             onVersionSelect={(version) => {
               setResourceVersion(version);
               setShowDrawer(false);

--- a/components/playground/ResourceVersionSearchAndResults.js
+++ b/components/playground/ResourceVersionSearchAndResults.js
@@ -33,10 +33,10 @@ import ResourceVersionSearchBar from "components/resources/ResourceVersionSearch
 import useDebouncedValue from "hooks/useDebouncedValue";
 
 const ResourceVersionSearchAndResults = ({
-  genericResource,
+  selectedResource,
   onVersionSelect,
 }) => {
-  const [versionSearch, setVersionSearch] = useState(!!genericResource);
+  const [versionSearch, setVersionSearch] = useState(!!selectedResource);
   const [debounceDelay, setDebounceDelay] = useState(500);
   const { state, dispatch } = useResources();
 
@@ -45,13 +45,13 @@ const ResourceVersionSearchAndResults = ({
     debounceDelay
   );
 
-  if (!genericResource) {
+  if (!selectedResource) {
     return <p>Select a resource to view a list of versions</p>;
   }
 
   const { data, loading, isLastPage, goToNextPage } = usePaginatedFetch(
     "/api/resource-versions",
-    buildResourceVersionQueryParams(genericResource.id, debouncedSearch),
+    buildResourceVersionQueryParams(selectedResource.id, debouncedSearch),
     PLAYGROUND_SEARCH_PAGE_SIZE
   );
 
@@ -138,7 +138,7 @@ const ResourceVersionSearchAndResults = ({
 };
 
 ResourceVersionSearchAndResults.propTypes = {
-  genericResource: PropTypes.object.isRequired,
+  selectedResource: PropTypes.object.isRequired,
   onVersionSelect: PropTypes.func.isRequired,
 };
 

--- a/components/playground/SelectedResource.js
+++ b/components/playground/SelectedResource.js
@@ -31,7 +31,7 @@ import ResourceSelectionDrawer from "components/playground/ResourceSelectionDraw
 import { copy } from "utils/shared-utils";
 
 const SelectedResource = (props) => {
-  const { resourceUri, setResource, clearEvaluation } = props;
+  const { resourceUri, setEvaluationResource, clearEvaluation } = props;
 
   const { data, loading } = useFetch(resourceUri ? `/api/occurrences` : null, {
     resourceUri: resourceUri,
@@ -60,7 +60,7 @@ const SelectedResource = (props) => {
                 label={"Clear Resource"}
                 buttonType={"icon"}
                 onClick={() => {
-                  setResource(null);
+                  setEvaluationResource(null);
                   clearEvaluation();
                 }}
                 showTooltip
@@ -78,7 +78,7 @@ const SelectedResource = (props) => {
             </>
           )}
           <ResourceSelectionDrawer
-            setResource={setResource}
+            setEvaluationResource={setEvaluationResource}
             clearEvaluation={clearEvaluation}
           />
         </div>
@@ -104,7 +104,7 @@ const SelectedResource = (props) => {
 
 SelectedResource.propTypes = {
   resourceUri: PropTypes.string,
-  setResource: PropTypes.func.isRequired,
+  setEvaluationResource: PropTypes.func.isRequired,
   clearEvaluation: PropTypes.func.isRequired,
 };
 

--- a/pages/api/resource-versions.js
+++ b/pages/api/resource-versions.js
@@ -27,16 +27,16 @@ export default async (req, res) => {
   const rodeUrl = getRodeUrl();
 
   try {
-    const genericResourceId = req.query.id;
+    const resourceId = req.query.id;
 
-    if (!genericResourceId) {
+    if (!resourceId) {
       return res.status(StatusCodes.BAD_REQUEST).json({
-        error: "Generic resource id must be provided",
+        error: "Resource id must be provided",
       });
     }
 
     const params = {
-      id: genericResourceId,
+      id: resourceId,
     };
 
     if (req.query.filter) {

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -116,7 +116,7 @@ const PolicyPlayground = () => {
       <div className={styles.resourceContainer}>
         <SelectedResource
           resourceUri={state.evaluationResource?.versionedResourceUri}
-          setResource={(data) =>
+          setEvaluationResource={(data) =>
             policyDispatch({
               type: policyActions.SET_EVALUATION_RESOURCE,
               data,

--- a/test/components/playground/ResourceSearchAndResults.spec.js
+++ b/test/components/playground/ResourceSearchAndResults.spec.js
@@ -25,7 +25,7 @@ jest.mock("hooks/usePaginatedFetch");
 
 describe("ResourceSearchAndResults", () => {
   let onResourceSelect,
-    genericResource,
+    selectedResource,
     state,
     dispatch,
     fetchResponse,
@@ -53,14 +53,14 @@ describe("ResourceSearchAndResults", () => {
       loading: false,
     };
 
-    genericResource = null;
+    selectedResource = null;
 
     usePaginatedFetch.mockReturnValue(fetchResponse);
 
     const utils = render(
       <ResourceSearchAndResults
         onResourceSelect={onResourceSelect}
-        genericResource={genericResource}
+        selectedResource={selectedResource}
       />,
       {
         resourceState: state,
@@ -116,11 +116,11 @@ describe("ResourceSearchAndResults", () => {
   });
 
   it("should indicate the currently selected resource", () => {
-    genericResource = fetchedResources[0];
+    selectedResource = fetchedResources[0];
     rerender(
       <ResourceSearchAndResults
         onResourceSelect={onResourceSelect}
-        genericResource={genericResource}
+        selectedResource={selectedResource}
       />
     );
     searchForResource();

--- a/test/components/playground/ResourceVersionSearchAndResults.spec.js
+++ b/test/components/playground/ResourceVersionSearchAndResults.spec.js
@@ -26,7 +26,7 @@ jest.mock("hooks/usePaginatedFetch");
 
 describe("ResourceVersionSearchAndResults", () => {
   let onVersionSelect,
-    genericResource,
+    selectedResource,
     state,
     dispatch,
     fetchResponse,
@@ -53,7 +53,7 @@ describe("ResourceVersionSearchAndResults", () => {
       loading: false,
     };
 
-    genericResource = { id: chance.string() };
+    selectedResource = { id: chance.string() };
 
     usePaginatedFetch.mockReturnValue(fetchResponse);
   });
@@ -67,7 +67,7 @@ describe("ResourceVersionSearchAndResults", () => {
     render(
       <ResourceVersionSearchAndResults
         onVersionSelect={onVersionSelect}
-        genericResource={genericResource}
+        selectedResource={selectedResource}
       />,
       {
         resourceState: state,
@@ -79,7 +79,7 @@ describe("ResourceVersionSearchAndResults", () => {
     expect(usePaginatedFetch).toHaveBeenCalledWith(
       "/api/resource-versions",
       {
-        id: genericResource.id,
+        id: selectedResource.id,
       },
       5
     );
@@ -89,7 +89,7 @@ describe("ResourceVersionSearchAndResults", () => {
     render(
       <ResourceVersionSearchAndResults
         onVersionSelect={onVersionSelect}
-        genericResource={genericResource}
+        selectedResource={selectedResource}
       />,
       {
         resourceState: state,
@@ -101,7 +101,7 @@ describe("ResourceVersionSearchAndResults", () => {
     expect(usePaginatedFetch).toHaveBeenLastCalledWith(
       "/api/resource-versions",
       {
-        id: genericResource.id,
+        id: selectedResource.id,
         filter: `version.contains("${state.versionSearchTerm}")`,
       },
       5
@@ -113,7 +113,7 @@ describe("ResourceVersionSearchAndResults", () => {
     render(
       <ResourceVersionSearchAndResults
         onVersionSelect={onVersionSelect}
-        genericResource={genericResource}
+        selectedResource={selectedResource}
       />,
       {
         resourceState: state,
@@ -125,7 +125,7 @@ describe("ResourceVersionSearchAndResults", () => {
     expect(usePaginatedFetch).toHaveBeenCalledWith(
       "/api/resource-versions",
       {
-        id: genericResource.id,
+        id: selectedResource.id,
       },
       5
     );
@@ -136,7 +136,7 @@ describe("ResourceVersionSearchAndResults", () => {
       const utils = render(
         <ResourceVersionSearchAndResults
           onVersionSelect={onVersionSelect}
-          genericResource={genericResource}
+          selectedResource={selectedResource}
         />,
         {
           resourceState: state,
@@ -212,7 +212,7 @@ describe("ResourceVersionSearchAndResults", () => {
       rerender(
         <ResourceVersionSearchAndResults
           onVersionSelect={onVersionSelect}
-          genericResource={null}
+          selectedResource={null}
         />,
         {
           resourceState: state,

--- a/test/components/playground/SelectedResource.spec.js
+++ b/test/components/playground/SelectedResource.spec.js
@@ -30,12 +30,12 @@ describe("SelectedResource", () => {
     name,
     version,
     fetchResponse,
-    setResource,
+    setEvaluationResource,
     clearEvaluation,
     rerender;
 
   beforeEach(() => {
-    setResource = jest.fn();
+    setEvaluationResource = jest.fn();
     clearEvaluation = jest.fn();
     fetchResponse = {
       data: {
@@ -56,7 +56,7 @@ describe("SelectedResource", () => {
       resourceUri = null;
       render(
         <SelectedResource
-          setResource={setResource}
+          setEvaluationResource={setEvaluationResource}
           clearEvaluation={clearEvaluation}
           resourceUri={resourceUri}
         />
@@ -83,7 +83,7 @@ describe("SelectedResource", () => {
       resourceUri = createMockResourceUri(name, version);
       const utils = render(
         <SelectedResource
-          setResource={setResource}
+          setEvaluationResource={setEvaluationResource}
           clearEvaluation={clearEvaluation}
           resourceUri={resourceUri}
         />
@@ -121,7 +121,7 @@ describe("SelectedResource", () => {
       fetchResponse.loading = true;
       rerender(
         <SelectedResource
-          setResource={setResource}
+          setEvaluationResource={setEvaluationResource}
           clearEvaluation={clearEvaluation}
           resourceUri={resourceUri}
         />
@@ -145,7 +145,9 @@ describe("SelectedResource", () => {
       expect(renderedButton).toBeInTheDocument();
 
       userEvent.click(renderedButton);
-      expect(setResource).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(null);
+      expect(setEvaluationResource)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(null);
       expect(clearEvaluation).toHaveBeenCalled();
     });
 

--- a/test/components/resources/ResourceSelectionDrawer.spec.js
+++ b/test/components/resources/ResourceSelectionDrawer.spec.js
@@ -25,14 +25,14 @@ import { RESOURCE_TYPES } from "utils/resource-utils";
 jest.mock("hooks/usePaginatedFetch");
 
 describe("ResourceSelectionDrawer", () => {
-  let setResource, clearEvaluation, dispatch, state;
+  let setEvaluationResource, clearEvaluation, dispatch, state;
 
   beforeEach(() => {
     dispatch = jest.fn();
     state = {
       searchTerm: chance.string(),
     };
-    setResource = jest.fn();
+    setEvaluationResource = jest.fn();
     clearEvaluation = jest.fn();
     const resourceResponse = {
       data: chance.n(
@@ -66,7 +66,7 @@ describe("ResourceSelectionDrawer", () => {
     render(
       <ResourceSelectionDrawer
         clearEvaluation={clearEvaluation}
-        setResource={setResource}
+        setEvaluationResource={setEvaluationResource}
       />,
       {
         resourceDispatch: dispatch,
@@ -148,7 +148,7 @@ describe("ResourceSelectionDrawer", () => {
     expect(screen.getByTestId("resourceSelectionDrawer")).toHaveClass(
       "closedDrawer"
     );
-    expect(setResource).toHaveBeenCalledTimes(1);
+    expect(setEvaluationResource).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/pages/api/resource-versions.spec.js
+++ b/test/pages/api/resource-versions.spec.js
@@ -25,16 +25,16 @@ describe("/api/resource-versions", () => {
     response,
     resourceVersions,
     rodeResponse,
-    genericResourceId,
+    resourceId,
     pageToken,
     rodeUrl;
 
   beforeEach(() => {
-    genericResourceId = chance.word();
+    resourceId = chance.word();
     request = {
       method: "GET",
       query: {
-        id: genericResourceId,
+        id: resourceId,
       },
     };
     pageToken = chance.string();
@@ -97,7 +97,7 @@ describe("/api/resource-versions", () => {
         .toHaveBeenCalledWith(StatusCodes.BAD_REQUEST);
 
       expect(response.json).toBeCalledTimes(1).toHaveBeenCalledWith({
-        error: "Generic resource id must be provided",
+        error: "Resource id must be provided",
       });
     });
   });
@@ -111,7 +111,7 @@ describe("/api/resource-versions", () => {
 
     it("should hit the Rode API", async () => {
       const expectedUrl = createExpectedUrl({
-        id: genericResourceId,
+        id: resourceId,
       });
 
       await handler(request, response);
@@ -122,7 +122,7 @@ describe("/api/resource-versions", () => {
     it("should pass the filter as a query param when a filter is specified", async () => {
       const filter = chance.string();
       const expectedUrl = createExpectedUrl({
-        id: genericResourceId,
+        id: resourceId,
         filter,
       });
 
@@ -134,7 +134,7 @@ describe("/api/resource-versions", () => {
     it("should pass the pageSize as a query param when a pageSize is specified", async () => {
       const pageSize = chance.d10();
       const expectedUrl = createExpectedUrl({
-        id: genericResourceId,
+        id: resourceId,
         pageSize,
       });
 
@@ -146,7 +146,7 @@ describe("/api/resource-versions", () => {
     it("should pass the pageToken as a query param when a pageToken is specified", async () => {
       const pageToken = chance.string();
       const expectedUrl = createExpectedUrl({
-        id: genericResourceId,
+        id: resourceId,
         pageToken,
       });
 


### PR DESCRIPTION
Just renaming some variables to remove the idea of a `generic-resource` from the code base.

Closes #115 