### PR TITLE
Policy groups: create new and dashboard

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -31,6 +31,7 @@ const Button = (props) => {
     className = "",
     loading = false,
     showTooltip = false,
+    type = "button",
     ...otherProps
   } = props;
 
@@ -61,6 +62,7 @@ const Button = (props) => {
         disabled={disabled || loading}
         data-tip={showTooltip}
         data-for={tooltipId}
+        type={type}
         {...otherProps}
       >
         <Loading type={"button"} loading={loading}>

--- a/components/Button.js
+++ b/components/Button.js
@@ -95,6 +95,7 @@ Button.propTypes = {
   className: PropTypes.string,
   loading: PropTypes.bool,
   showTooltip: PropTypes.bool,
+  type: PropTypes.oneOf(["button", "submit", "reset"]),
 };
 
 export default Button;

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -47,6 +47,13 @@ const policyLinks = [
   },
 ];
 
+const adminLinks = [
+  {
+    href: "/policy-groups",
+    label: "Policy Groups"
+  }
+]
+
 const navigationSections = [
   {
     title: "Resources",
@@ -55,6 +62,10 @@ const navigationSections = [
   {
     title: "Policies",
     links: policyLinks,
+  },
+  {
+    title: "Admin",
+    links: adminLinks,
   },
 ];
 

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -50,9 +50,9 @@ const policyLinks = [
 const adminLinks = [
   {
     href: "/policy-groups",
-    label: "Policy Groups"
-  }
-]
+    label: "Policy Groups",
+  },
+];
 
 const navigationSections = [
   {

--- a/components/layout/PageHeader.js
+++ b/components/layout/PageHeader.js
@@ -17,11 +17,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Header.module.scss";
-
-// TODO: create pageHeader in typography, share between pages
+import { useTheme } from "providers/theme";
 
 const PageHeader = ({ children }) => {
-  return <div className={styles.pageHeader}>{children}</div>;
+  const { theme } = useTheme();
+
+  return (
+    <div className={`${styles[theme]} ${styles.pageHeader}`}>{children}</div>
+  );
 };
 
 PageHeader.propTypes = {

--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -170,7 +170,7 @@ const PolicyForm = ({
         </div>
       </Modal>
       <PageHeader>
-        <h1 className={styles.heading}>{title}</h1>
+        <h1>{title}</h1>
       </PageHeader>
       <form onSubmit={onSubmit} className={`${styles.form} ${styles[theme]}`}>
         <div className={styles.policyInputsContainer}>

--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -169,10 +169,10 @@ const PolicyForm = ({
           />
         </div>
       </Modal>
+      <PageHeader>
+        <h1 className={styles.heading}>{title}</h1>
+      </PageHeader>
       <form onSubmit={onSubmit} className={`${styles.form} ${styles[theme]}`}>
-        <PageHeader>
-          <h1 className={styles.heading}>{title}</h1>
-        </PageHeader>
         <div className={styles.policyInputsContainer}>
           <Input
             name={"name"}

--- a/hooks/useFormValidation.js
+++ b/hooks/useFormValidation.js
@@ -45,8 +45,8 @@ export const useFormValidation = (schema) => {
     return isValid;
   };
 
-  const validateField = (event) => {
-    if (!formData) {
+  const validateField = (event, forceValidation = false) => {
+    if (!forceValidation && !formData) {
       return;
     }
     const field = event.target.name;

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -70,44 +70,42 @@ export default async (req, res) => {
         .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
     }
   }
-  if (req.method === "POST") {
-    try {
-      const postBody = mapToApiModel(req);
+  try {
+    const postBody = mapToApiModel(req);
 
-      const response = await post(`${rodeUrl}/v1alpha1/policies`, postBody);
+    const response = await post(`${rodeUrl}/v1alpha1/policies`, postBody);
 
-      if (!response.ok) {
-        console.error(`Unsuccessful response from Rode: ${response.status}`);
+    if (!response.ok) {
+      console.error(`Unsuccessful response from Rode: ${response.status}`);
 
-        const parsedResponse = await response.json();
+      const parsedResponse = await response.json();
 
-        if (
-          parsedResponse?.message?.includes("failed to compile") ||
-          parsedResponse?.message?.includes("failed to parse")
-        ) {
-          const validationError = {
-            errors: parsedResponse.details[0].errors,
-            isValid: false,
-          };
+      if (
+        parsedResponse?.message?.includes("failed to compile") ||
+        parsedResponse?.message?.includes("failed to parse")
+      ) {
+        const validationError = {
+          errors: parsedResponse.details[0].errors,
+          isValid: false,
+        };
 
-          return res.status(StatusCodes.BAD_REQUEST).json(validationError);
-        }
-
-        return res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
+        return res.status(StatusCodes.BAD_REQUEST).json(validationError);
       }
-
-      const createPolicyResponse = await response.json();
-      const policy = mapToClientModel(createPolicyResponse);
-
-      return res.status(StatusCodes.OK).json(policy);
-    } catch (error) {
-      console.error("Error creating policy", error);
 
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
     }
+
+    const createPolicyResponse = await response.json();
+    const policy = mapToClientModel(createPolicyResponse);
+
+    return res.status(StatusCodes.OK).json(policy);
+  } catch (error) {
+    console.error("Error creating policy", error);
+
+    return res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
   }
 };

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -15,7 +15,12 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import { get, getRodeUrl, post } from "./utils/api-utils";
+import {
+  buildPaginationParams,
+  get,
+  getRodeUrl,
+  post,
+} from "./utils/api-utils";
 import { mapToApiModel, mapToClientModel } from "./utils/policy-utils";
 
 const ALLOWED_METHODS = ["GET", "POST"];
@@ -32,20 +37,12 @@ export default async (req, res) => {
   if (req.method === "GET") {
     try {
       const searchTerm = req.query.filter;
-      let filter = {};
+      let params = buildPaginationParams(req);
       if (searchTerm) {
-        filter = {
-          filter: `policy.name.contains("${searchTerm}")`,
-        };
-      }
-      if (req.query.pageSize) {
-        filter.pageSize = req.query.pageSize;
-      }
-      if (req.query.pageToken) {
-        filter.pageToken = req.query.pageToken;
+        params.filter = `policy.name.contains("${searchTerm}")`;
       }
       const response = await get(
-        `${rodeUrl}/v1alpha1/policies?${new URLSearchParams(filter)}`
+        `${rodeUrl}/v1alpha1/policies?${new URLSearchParams(params)}`
       );
 
       if (!response.ok) {

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -39,8 +39,9 @@ export default async (req, res) => {
       const searchTerm = req.query.filter;
       let params = buildPaginationParams(req);
       if (searchTerm) {
-        params.filter = `policy.name.contains("${searchTerm}")`;
+        params.filter = `name.contains("${searchTerm}")`;
       }
+
       const response = await get(
         `${rodeUrl}/v1alpha1/policies?${new URLSearchParams(params)}`
       );

--- a/pages/api/policies.js
+++ b/pages/api/policies.js
@@ -58,19 +58,18 @@ export default async (req, res) => {
         mapToClientModel(policy)
       );
 
-      res.status(StatusCodes.OK).json({
+      return res.status(StatusCodes.OK).json({
         data: policies,
         pageToken: listPoliciesResponse.nextPageToken,
       });
     } catch (error) {
       console.error("Error listing policies", error);
 
-      res
+      return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
     }
   }
-
   if (req.method === "POST") {
     try {
       const postBody = mapToApiModel(req);
@@ -102,11 +101,11 @@ export default async (req, res) => {
       const createPolicyResponse = await response.json();
       const policy = mapToClientModel(createPolicyResponse);
 
-      res.status(StatusCodes.OK).json(policy);
+      return res.status(StatusCodes.OK).json(policy);
     } catch (error) {
       console.error("Error creating policy", error);
 
-      res
+      return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
     }

--- a/pages/api/policy-groups.js
+++ b/pages/api/policy-groups.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StatusCodes, ReasonPhrases } from "http-status-codes";
+import { get, getRodeUrl, post } from "./utils/api-utils";
+
+const ALLOWED_METHODS = ["GET", "POST"];
+
+export default async (req, res) => {
+  if (!ALLOWED_METHODS.includes(req.method)) {
+    return res
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ error: ReasonPhrases.METHOD_NOT_ALLOWED });
+  }
+
+  const rodeUrl = getRodeUrl();
+
+  if (req.method === "GET") {
+    try {
+      const params = {};
+
+      if (req.query.filter) {
+        params.filter = req.query.filter;
+      }
+      if (req.query.pageSize) {
+        params.pageSize = req.query.pageSize;
+      }
+      if (req.query.pageToken) {
+        params.pageToken = req.query.pageToken;
+      }
+      const response = await get(
+        `${rodeUrl}/v1alpha1/policy-groups?${new URLSearchParams(params)}`
+      );
+
+      if (!response.ok) {
+        console.error(`Unsuccessful response from Rode: ${response.status}`);
+        return res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
+      }
+
+      const listPolicyGroupsResponse = await response.json();
+
+      const policyGroups = listPolicyGroupsResponse.policyGroups;
+
+      res.status(StatusCodes.OK).json({
+        data: policyGroups,
+        pageToken: listPolicyGroupsResponse.nextPageToken,
+      });
+    } catch (error) {
+      console.error("Error listing policy groups", error);
+
+      res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
+    }
+  }
+  if (req.method === "POST") {
+    try {
+      const requestBody = req.body;
+      const response = await post(
+        `${rodeUrl}/v1alpha1/policy-groups`,
+        requestBody
+      );
+
+      if (!response.ok) {
+        console.error(`Unsuccessful response from Rode: ${response.status}`);
+        return res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
+      }
+
+      const createPolicyGroupResponse = await response.json();
+
+      const policyGroup = createPolicyGroupResponse;
+
+      res.status(StatusCodes.OK).json({
+        data: policyGroup,
+        pageToken: createPolicyGroupResponse.nextPageToken,
+      });
+    } catch (error) {
+      console.error("Error listing policy groups", error);
+
+      res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
+    }
+  }
+};

--- a/pages/api/policy-groups.js
+++ b/pages/api/policy-groups.js
@@ -41,6 +41,7 @@ export default async (req, res) => {
       if (req.query.pageToken) {
         params.pageToken = req.query.pageToken;
       }
+
       const response = await get(
         `${rodeUrl}/v1alpha1/policy-groups?${new URLSearchParams(params)}`
       );
@@ -85,12 +86,7 @@ export default async (req, res) => {
 
       const createPolicyGroupResponse = await response.json();
 
-      const policyGroup = createPolicyGroupResponse;
-
-      res.status(StatusCodes.OK).json({
-        data: policyGroup,
-        pageToken: createPolicyGroupResponse.nextPageToken,
-      });
+      res.status(StatusCodes.OK).json(createPolicyGroupResponse);
     } catch (error) {
       console.error("Error listing policy groups", error);
 

--- a/pages/api/policy-groups.js
+++ b/pages/api/policy-groups.js
@@ -56,18 +56,19 @@ export default async (req, res) => {
 
       const policyGroups = listPolicyGroupsResponse.policyGroups;
 
-      res.status(StatusCodes.OK).json({
+      return res.status(StatusCodes.OK).json({
         data: policyGroups,
         pageToken: listPolicyGroupsResponse.nextPageToken,
       });
     } catch (error) {
       console.error("Error listing policy groups", error);
 
-      res
+      return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
     }
   }
+
   if (req.method === "POST") {
     try {
       const response = await post(
@@ -84,11 +85,11 @@ export default async (req, res) => {
 
       const createPolicyGroupResponse = await response.json();
 
-      res.status(StatusCodes.OK).json(createPolicyGroupResponse);
+      return res.status(StatusCodes.OK).json(createPolicyGroupResponse);
     } catch (error) {
       console.error("Error listing policy groups", error);
 
-      res
+      return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
     }

--- a/pages/api/policy-groups.js
+++ b/pages/api/policy-groups.js
@@ -69,29 +69,24 @@ export default async (req, res) => {
     }
   }
 
-  if (req.method === "POST") {
-    try {
-      const response = await post(
-        `${rodeUrl}/v1alpha1/policy-groups`,
-        req.body
-      );
+  try {
+    const response = await post(`${rodeUrl}/v1alpha1/policy-groups`, req.body);
 
-      if (!response.ok) {
-        console.error(`Unsuccessful response from Rode: ${response.status}`);
-        return res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
-      }
-
-      const createPolicyGroupResponse = await response.json();
-
-      return res.status(StatusCodes.OK).json(createPolicyGroupResponse);
-    } catch (error) {
-      console.error("Error listing policy groups", error);
-
+    if (!response.ok) {
+      console.error(`Unsuccessful response from Rode: ${response.status}`);
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
     }
+
+    const createPolicyGroupResponse = await response.json();
+
+    return res.status(StatusCodes.OK).json(createPolicyGroupResponse);
+  } catch (error) {
+    console.error("Error listing policy groups", error);
+
+    return res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
   }
 };

--- a/pages/api/policy-groups.js
+++ b/pages/api/policy-groups.js
@@ -32,6 +32,7 @@ export default async (req, res) => {
     try {
       const params = {};
 
+      // TODO: pull out query param building into helper method
       if (req.query.filter) {
         params.filter = req.query.filter;
       }

--- a/pages/api/policy-groups.js
+++ b/pages/api/policy-groups.js
@@ -15,7 +15,12 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import { get, getRodeUrl, post } from "./utils/api-utils";
+import {
+  buildPaginationParams,
+  get,
+  getRodeUrl,
+  post,
+} from "./utils/api-utils";
 
 const ALLOWED_METHODS = ["GET", "POST"];
 
@@ -30,17 +35,10 @@ export default async (req, res) => {
 
   if (req.method === "GET") {
     try {
-      const params = {};
+      const params = buildPaginationParams(req);
 
-      // TODO: pull out query param building into helper method
       if (req.query.filter) {
         params.filter = req.query.filter;
-      }
-      if (req.query.pageSize) {
-        params.pageSize = req.query.pageSize;
-      }
-      if (req.query.pageToken) {
-        params.pageToken = req.query.pageToken;
       }
 
       const response = await get(
@@ -72,10 +70,9 @@ export default async (req, res) => {
   }
   if (req.method === "POST") {
     try {
-      const requestBody = req.body;
       const response = await post(
         `${rodeUrl}/v1alpha1/policy-groups`,
-        requestBody
+        req.body
       );
 
       if (!response.ok) {

--- a/pages/api/resource-versions.js
+++ b/pages/api/resource-versions.js
@@ -49,9 +49,7 @@ export default async (req, res) => {
       params.pageToken = req.query.pageToken;
     }
     const response = await get(
-      `${rodeUrl}/v1alpha1/generic-resource-versions?${new URLSearchParams(
-        params
-      )}`
+      `${rodeUrl}/v1alpha1/resource-versions?${new URLSearchParams(params)}`
     );
 
     if (!response.ok) {

--- a/pages/api/resource-versions.js
+++ b/pages/api/resource-versions.js
@@ -15,7 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import { get, getRodeUrl } from "./utils/api-utils";
+import { buildPaginationParams, get, getRodeUrl } from "./utils/api-utils";
 
 export default async (req, res) => {
   if (req.method !== "GET") {
@@ -37,17 +37,13 @@ export default async (req, res) => {
 
     const params = {
       id: resourceId,
+      ...buildPaginationParams(req),
     };
 
     if (req.query.filter) {
       params.filter = req.query.filter;
     }
-    if (req.query.pageSize) {
-      params.pageSize = req.query.pageSize;
-    }
-    if (req.query.pageToken) {
-      params.pageToken = req.query.pageToken;
-    }
+
     const response = await get(
       `${rodeUrl}/v1alpha1/resource-versions?${new URLSearchParams(params)}`
     );

--- a/pages/api/resources.js
+++ b/pages/api/resources.js
@@ -35,14 +35,14 @@ export default async (req, res) => {
     if (searchTerm && resourceTypes) {
       const resources = resourceTypes.split(",");
       params.filter = `name.contains("${searchTerm}")&&(${resources
-        .map((type) => `"type"=="${type}"`)
+        .map((type) => `type=="${type}"`)
         .join("||")})`;
     } else if (searchTerm) {
       params.filter = `name.contains("${searchTerm}")`;
     } else if (resourceTypes) {
       const resources = resourceTypes.split(",");
       params.filter = `${resources
-        .map((type) => `"type"=="${type}"`)
+        .map((type) => `type=="${type}"`)
         .join("||")}`;
     }
 

--- a/pages/api/resources.js
+++ b/pages/api/resources.js
@@ -15,7 +15,7 @@
  */
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
-import { get, getRodeUrl } from "./utils/api-utils";
+import { buildPaginationParams, get, getRodeUrl } from "./utils/api-utils";
 
 export default async (req, res) => {
   if (req.method !== "GET") {
@@ -30,35 +30,24 @@ export default async (req, res) => {
     const searchTerm = req.query.searchTerm;
     const resourceTypes = req.query.resourceTypes;
 
-    let filter = {};
+    let params = buildPaginationParams(req);
 
     if (searchTerm && resourceTypes) {
       const resources = resourceTypes.split(",");
-      filter = {
-        filter: `name.contains("${searchTerm}")&&(${resources
-          .map((type) => `"type"=="${type}"`)
-          .join("||")})`,
-      };
+      params.filter = `name.contains("${searchTerm}")&&(${resources
+        .map((type) => `"type"=="${type}"`)
+        .join("||")})`;
     } else if (searchTerm) {
-      filter = {
-        filter: `name.contains("${searchTerm}")`,
-      };
+      params.filter = `name.contains("${searchTerm}")`;
     } else if (resourceTypes) {
       const resources = resourceTypes.split(",");
-      filter = {
-        filter: `${resources.map((type) => `"type"=="${type}"`).join("||")}`,
-      };
-    }
-
-    if (req.query.pageSize) {
-      filter.pageSize = req.query.pageSize;
-    }
-    if (req.query.pageToken) {
-      filter.pageToken = req.query.pageToken;
+      params.filter = `${resources
+        .map((type) => `"type"=="${type}"`)
+        .join("||")}`;
     }
 
     const response = await get(
-      `${rodeUrl}/v1alpha1/resources?${new URLSearchParams(filter)}`
+      `${rodeUrl}/v1alpha1/resources?${new URLSearchParams(params)}`
     );
 
     if (!response.ok) {

--- a/pages/api/resources.js
+++ b/pages/api/resources.js
@@ -58,7 +58,7 @@ export default async (req, res) => {
     }
 
     const response = await get(
-      `${rodeUrl}/v1alpha1/generic-resources?${new URLSearchParams(filter)}`
+      `${rodeUrl}/v1alpha1/resources?${new URLSearchParams(filter)}`
     );
 
     if (!response.ok) {
@@ -69,7 +69,7 @@ export default async (req, res) => {
     }
 
     const listResourcesResponse = await response.json();
-    const resources = listResourcesResponse.genericResources;
+    const resources = listResourcesResponse.resources;
 
     res.status(StatusCodes.OK).json({
       data: resources,

--- a/pages/api/utils/api-utils.js
+++ b/pages/api/utils/api-utils.js
@@ -38,3 +38,16 @@ export const patch = (endpoint, body) => fetch(endpoint, "PATCH", body);
 export const get = (endpoint) => fetch(endpoint, "GET");
 
 export const del = (endpoint) => fetch(endpoint, "DELETE");
+
+export const buildPaginationParams = (request) => {
+  let params = {};
+
+  if (request.query.pageSize) {
+    params.pageSize = request.query.pageSize;
+  }
+  if (request.query.pageToken) {
+    params.pageToken = request.query.pageToken;
+  }
+
+  return params;
+};

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -96,7 +96,7 @@ const PolicyPlayground = () => {
   return (
     <div className={`${styles[theme]} ${styles.contentContainer}`}>
       <PageHeader>
-        <h1 className={styles.pageTitle}>Policy Playground</h1>
+        <h1>Policy Playground</h1>
         <p className={styles.instructions}>
           Choose a resource, pick a policy, and evaluate.
         </p>

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -18,16 +18,49 @@ import React from "react";
 import { useTheme } from "providers/theme";
 import { useRouter } from "next/router";
 import Button from "../components/Button";
+import PageHeader from "../components/layout/PageHeader";
+import { usePaginatedFetch } from "../hooks/usePaginatedFetch";
+import Loading from "../components/Loading";
 
 const PolicyGroups = () => {
   const { theme } = useTheme();
   const router = useRouter();
 
+  const {data, loading, isLastPage, goToNextPage} = usePaginatedFetch("/api/policy-groups", {}, 100);
+
   return (
+    <>
+      <PageHeader>
+        <p>Manage Policy Groups</p>
+      </PageHeader>
     <div>
-      <p>Policy Groups</p>
+      <Loading loading={loading}>
+        {
+          data?.length > 0 ? (
+            <>
+            {
+              data.map((group) => (
+                <div key={group.id}>
+                  <p>{group.toString()}</p>
+                </div>
+              ))
+            }
+              {!isLastPage && (
+                <Button
+                  buttonType="text"
+                  onClick={goToNextPage}
+                  label={"View More"}
+                />
+              )}
+              </>
+          )
+            :
+            <p>No policy groups exist.</p>
+        }
+      </Loading>
       <Button label={'Create New Policy Group'} onClick={() => router.push("/policy-groups/new")}/>
     </div>
+    </>
   );
 };
 

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -23,8 +23,6 @@ import { usePaginatedFetch } from "hooks/usePaginatedFetch";
 import Loading from "components/Loading";
 import styles from "styles/modules/PolicyGroupDashboard.module.scss";
 
-// TODO: tests
-
 const PolicyGroups = () => {
   const { theme } = useTheme();
   const router = useRouter();

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { useTheme } from "providers/theme";
+import { useRouter } from "next/router";
+import Button from "../components/Button";
+
+const PolicyGroups = () => {
+  const { theme } = useTheme();
+  const router = useRouter();
+
+  return (
+    <div>
+      <p>Policy Groups</p>
+      <Button label={'Create New Policy Group'} onClick={() => router.push("/policy-groups/new")}/>
+    </div>
+  );
+};
+
+export default PolicyGroups;

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -41,7 +41,7 @@ const PolicyGroups = () => {
         className={styles.createNewButton}
       />
       <PageHeader>
-        <h1 className={styles.pageHeader}>Manage Policy Groups</h1>
+        <h1>Manage Policy Groups</h1>
       </PageHeader>
       <div className={styles.cardsContainer}>
         <Loading loading={loading}>

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -50,7 +50,7 @@ const PolicyGroups = () => {
               {data.map((group) => (
                 <div key={group.name} className={styles.card}>
                   <p className={styles.policyGroupName}>{group.name}</p>
-                  <p>{group.description}</p>
+                  {group.description && <p>{group.description}</p>}
                 </div>
               ))}
               {!isLastPage && (

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -23,6 +23,8 @@ import { usePaginatedFetch } from "hooks/usePaginatedFetch";
 import Loading from "components/Loading";
 import styles from "styles/modules/PolicyGroupDashboard.module.scss";
 
+// TODO: tests
+
 const PolicyGroups = () => {
   const { theme } = useTheme();
   const router = useRouter();
@@ -66,7 +68,6 @@ const PolicyGroups = () => {
           )}
         </Loading>
       </div>
-
     </div>
   );
 };

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -17,34 +17,42 @@
 import React from "react";
 import { useTheme } from "providers/theme";
 import { useRouter } from "next/router";
-import Button from "../components/Button";
-import PageHeader from "../components/layout/PageHeader";
-import { usePaginatedFetch } from "../hooks/usePaginatedFetch";
-import Loading from "../components/Loading";
+import Button from "components/Button";
+import PageHeader from "components/layout/PageHeader";
+import { usePaginatedFetch } from "hooks/usePaginatedFetch";
+import Loading from "components/Loading";
+import styles from "styles/modules/PolicyGroupDashboard.module.scss";
 
 const PolicyGroups = () => {
   const { theme } = useTheme();
   const router = useRouter();
 
-  const {data, loading, isLastPage, goToNextPage} = usePaginatedFetch("/api/policy-groups", {}, 100);
+  const { data, loading, isLastPage, goToNextPage } = usePaginatedFetch(
+    "/api/policy-groups",
+    {},
+    100
+  );
 
   return (
-    <>
+    <div className={styles[theme]}>
+      <Button
+        label={"Create New Policy Group"}
+        onClick={() => router.push("/policy-groups/new")}
+        className={styles.createNewButton}
+      />
       <PageHeader>
-        <p>Manage Policy Groups</p>
+        <h1 className={styles.pageHeader}>Manage Policy Groups</h1>
       </PageHeader>
-    <div>
-      <Loading loading={loading}>
-        {
-          data?.length > 0 ? (
+      <div className={styles.cardsContainer}>
+        <Loading loading={loading}>
+          {data?.length > 0 ? (
             <>
-            {
-              data.map((group) => (
-                <div key={group.id}>
-                  <p>{group.toString()}</p>
+              {data.map((group) => (
+                <div key={group.name} className={styles.card}>
+                  <p className={styles.policyGroupName}>{group.name}</p>
+                  <p>{group.description}</p>
                 </div>
-              ))
-            }
+              ))}
               {!isLastPage && (
                 <Button
                   buttonType="text"
@@ -52,15 +60,14 @@ const PolicyGroups = () => {
                   label={"View More"}
                 />
               )}
-              </>
-          )
-            :
+            </>
+          ) : (
             <p>No policy groups exist.</p>
-        }
-      </Loading>
-      <Button label={'Create New Policy Group'} onClick={() => router.push("/policy-groups/new")}/>
+          )}
+        </Loading>
+      </div>
+
     </div>
-    </>
   );
 };
 

--- a/pages/policy-groups/new.js
+++ b/pages/policy-groups/new.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, {useState} from "react";
 import { useTheme } from "providers/theme";
 import { useRouter } from "next/router";
 import Button from "../../components/Button";
@@ -24,16 +24,60 @@ const PolicyGroups = () => {
   const { theme } = useTheme();
   const router = useRouter();
 
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const onSubmit = async (event) => {
+    event.preventDefault();
+    const formData = {
+      name,
+      description
+    };
+
+    const response = await fetch('/api/policy-groups', {
+      method: "POST",
+      body: JSON.stringify(formData),
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+
+    if (!response.ok) {
+      console.log('error occurred',response);
+      return;
+    }
+
+    const parsedResponse = await response.json();
+    console.log('here successful save', parsedResponse);
+
+  };
+
   return (
     <div>
       <p>New Policy Groups</p>
-      <form>
-
-      <Input name={'name'} label={'Policy Group Name'} onChange={() => {}}/>
-      <Input name={'description'} label={'Description'} onChange={() => {}}/>
-        <Button label={'Save Policy Group'} type={"submit"}/>
-        <Button label={'Cancel'} onClick={() => router.back()} buttonType={"text"}/>
-
+      <form onSubmit={onSubmit}>
+        <Input
+          name={"name"}
+          label={"Policy Group Name"}
+          onChange={(event) => {
+            setName(event.target.value);
+          }}
+          value={name}
+        />
+        <Input
+          name={"description"}
+          label={"Description"}
+          onChange={(event) => {
+            setDescription(event.target.value);
+          }}
+          value={description}
+        />
+        <Button label={"Save Policy Group"} type={"submit"} />
+        <Button
+          label={"Cancel"}
+          onClick={() => router.back()}
+          buttonType={"text"}
+        />
       </form>
     </div>
   );

--- a/pages/policy-groups/new.js
+++ b/pages/policy-groups/new.js
@@ -25,8 +25,7 @@ import { useFormValidation } from "hooks/useFormValidation";
 import { schema } from "schemas/policy-group-form";
 import { showError } from "utils/toast-utils";
 
-// TODO: tests
-const PolicyGroups = () => {
+const CreateNewPolicyGroup = () => {
   const { theme } = useTheme();
   const router = useRouter();
 
@@ -85,6 +84,7 @@ const PolicyGroups = () => {
             value={name}
             horizontal
             onBlur={validateField}
+            required
             error={errors.name}
           />
           <p className={styles.hint}>
@@ -139,4 +139,4 @@ const PolicyGroups = () => {
   );
 };
 
-export default PolicyGroups;
+export default CreateNewPolicyGroup;

--- a/pages/policy-groups/new.js
+++ b/pages/policy-groups/new.js
@@ -23,17 +23,18 @@ import styles from "styles/modules/PolicyGroupForm.module.scss";
 import PageHeader from "components/layout/PageHeader";
 import { useFormValidation } from "hooks/useFormValidation";
 import { schema } from "schemas/policy-group-form";
+import { showError } from "utils/toast-utils";
 
+// TODO: tests
 const PolicyGroups = () => {
   const { theme } = useTheme();
   const router = useRouter();
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const { isValid, validateField, errors } = useFormValidation(schema);
-
-  console.log("errors", errors);
 
   const onSubmit = async (event) => {
     event.preventDefault();
@@ -48,6 +49,7 @@ const PolicyGroups = () => {
       return;
     }
 
+    setLoading(true);
     const response = await fetch("/api/policy-groups", {
       method: "POST",
       body: JSON.stringify(formData),
@@ -55,14 +57,12 @@ const PolicyGroups = () => {
         "Content-Type": "application/json",
       },
     });
+    setLoading(false);
 
     if (!response.ok) {
-      console.log("error occurred", response);
+      showError("Failed to create the policy group.");
       return;
     }
-
-    const parsedResponse = await response.json();
-    console.log("here successful save", parsedResponse);
 
     // TODO: once implemented, push to created policy group page
     router.push("/policy-groups");
@@ -104,12 +104,17 @@ const PolicyGroups = () => {
           />
         </div>
         <div className={styles.buttonsContainer}>
-          <Button label={"Save Policy Group"} type={"submit"} />
+          <Button
+            label={"Save Policy Group"}
+            type={"submit"}
+            loading={loading}
+          />
 
           <Button
             label={"Cancel"}
             onClick={() => router.back()}
             buttonType={"text"}
+            disabled={loading}
           />
         </div>
       </form>

--- a/pages/policy-groups/new.js
+++ b/pages/policy-groups/new.js
@@ -68,74 +68,78 @@ const CreateNewPolicyGroup = () => {
   };
 
   return (
-    <div className={`${styles.pageContainer} ${styles[theme]}`}>
+    <>
       <PageHeader>
-        <h1 className={styles.pageHeader}>Create Policy Group</h1>
+        <h1>Create Policy Group</h1>
       </PageHeader>
-      <form onSubmit={onSubmit} className={styles.form}>
-        <div className={styles.formContentContainer}>
-          <Input
-            name={"name"}
-            label={"Policy Group Name"}
-            placeholder={"ex: pci-bundle"}
-            onChange={(event) => {
-              setName(event.target.value);
-            }}
-            value={name}
-            horizontal
-            onBlur={validateField}
-            required
-            error={errors.name}
-          />
-          <p className={styles.hint}>
-            Please note: policy group name cannot be changed after creation.
-          </p>
-          <Input
-            name={"description"}
-            label={"Description"}
-            placeholder={"A summary of the intended use for this policy group"}
-            onChange={(event) => {
-              setDescription(event.target.value);
-            }}
-            value={description}
-            horizontal
-            onBlur={validateField}
-            error={errors.description}
-          />
-        </div>
-        <div className={styles.buttonsContainer}>
-          <Button
-            label={"Save Policy Group"}
-            type={"submit"}
-            loading={loading}
-          />
+      <div className={`${styles.pageContainer} ${styles[theme]}`}>
+        <form onSubmit={onSubmit} className={styles.form}>
+          <div className={styles.formContentContainer}>
+            <Input
+              name={"name"}
+              label={"Policy Group Name"}
+              placeholder={"ex: pci-bundle"}
+              onChange={(event) => {
+                setName(event.target.value);
+              }}
+              value={name}
+              horizontal
+              onBlur={validateField}
+              required
+              error={errors.name}
+            />
+            <p className={styles.hint}>
+              Please note: policy group name cannot be changed after creation.
+            </p>
+            <Input
+              name={"description"}
+              label={"Description"}
+              placeholder={
+                "A summary of the intended use for this policy group"
+              }
+              onChange={(event) => {
+                setDescription(event.target.value);
+              }}
+              value={description}
+              horizontal
+              onBlur={validateField}
+              error={errors.description}
+            />
+          </div>
+          <div className={styles.buttonsContainer}>
+            <Button
+              label={"Save Policy Group"}
+              type={"submit"}
+              loading={loading}
+            />
 
-          <Button
-            label={"Cancel"}
-            onClick={() => router.back()}
-            buttonType={"text"}
-            disabled={loading}
-          />
-        </div>
-      </form>
-      <div className={styles.formNotes}>
-        <div>
-          <p>Policy Group Name Guidelines</p>
-          <ul>
-            <li>Lowercase</li>
-            <li>Alphanumeric Characters</li>
-            <li>Dashes or Hyphens</li>
-            <li>Underscores</li>
-          </ul>
-        </div>
-        <div>
-          <p>Examples</p>
-          <code>development_3</code>
-          <code>pci-requirements</code>
-          <code>docker_images_prod</code>
+            <Button
+              label={"Cancel"}
+              onClick={() => router.back()}
+              buttonType={"text"}
+              disabled={loading}
+            />
+          </div>
+        </form>
+        <div className={styles.formNotes}>
+          <div>
+            <p>Policy Group Name Guidelines</p>
+            <ul>
+              <li>Lowercase</li>
+              <li>Alphanumeric Characters</li>
+              <li>Dashes or Hyphens</li>
+              <li>Underscores</li>
+            </ul>
+          </div>
+          <div>
+            <p>Examples</p>
+            <code>development_3</code>
+            <code>pci-requirements</code>
+            <code>docker_images_prod</code>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/pages/policy-groups/new.js
+++ b/pages/policy-groups/new.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { useTheme } from "providers/theme";
+import { useRouter } from "next/router";
+import Button from "../../components/Button";
+import Input from "../../components/Input";
+
+const PolicyGroups = () => {
+  const { theme } = useTheme();
+  const router = useRouter();
+
+  return (
+    <div>
+      <p>New Policy Groups</p>
+      <form>
+
+      <Input name={'name'} label={'Policy Group Name'} onChange={() => {}}/>
+      <Input name={'description'} label={'Description'} onChange={() => {}}/>
+        <Button label={'Save Policy Group'} type={"submit"}/>
+        <Button label={'Cancel'} onClick={() => router.back()} buttonType={"text"}/>
+
+      </form>
+    </div>
+  );
+};
+
+export default PolicyGroups;

--- a/pages/policy-groups/new.js
+++ b/pages/policy-groups/new.js
@@ -88,8 +88,8 @@ const CreateNewPolicyGroup = () => {
               required
               error={errors.name}
             />
-            <p className={styles.hint}>
-              Please note: policy group name cannot be changed after creation.
+            <p className={styles.hint} spacing={"Policy Group Name"}>
+              <span>Please note:</span> Policy Group Name cannot be changed after creation.
             </p>
             <Input
               name={"description"}
@@ -123,7 +123,7 @@ const CreateNewPolicyGroup = () => {
         </form>
         <div className={styles.formNotes}>
           <div>
-            <p>Policy Group Name Guidelines</p>
+            <h2>Policy Group Name Guidelines</h2>
             <ul>
               <li>Lowercase</li>
               <li>Alphanumeric Characters</li>

--- a/pages/policy-groups/new.js
+++ b/pages/policy-groups/new.js
@@ -84,12 +84,13 @@ const CreateNewPolicyGroup = () => {
               }}
               value={name}
               horizontal
-              onBlur={validateField}
+              onBlur={(event) => validateField(event, true)}
               required
               error={errors.name}
             />
             <p className={styles.hint} spacing={"Policy Group Name"}>
-              <span>Please note:</span> Policy Group Name cannot be changed after creation.
+              <span>Please note:</span> Policy Group Name cannot be changed
+              after creation.
             </p>
             <Input
               name={"description"}

--- a/schemas/policy-group-form.js
+++ b/schemas/policy-group-form.js
@@ -17,6 +17,13 @@
 import * as yup from "yup";
 
 export const schema = yup.object().shape({
-  name: yup.string().required().label("Policy Group Name").matches(/^([a-z]*|\d*|[-_]*)*$/g, "Invalid character(s). Please refer to name guidelines."),
+  name: yup
+    .string()
+    .required()
+    .label("Policy Group Name")
+    .matches(
+      /^([a-z]*|\d*|[-_]*)*$/g,
+      "Invalid character(s). Please refer to name guidelines."
+    ),
   description: yup.string().label("Description"),
 });

--- a/schemas/policy-group-form.js
+++ b/schemas/policy-group-form.js
@@ -22,8 +22,8 @@ export const schema = yup.object().shape({
     .required()
     .label("Policy Group Name")
     .matches(
-      /^([a-z]*|\d*|[-_]*)*$/g,
-      "Invalid character(s). Please refer to name guidelines."
+      /^[a-z\d\-_]+$/g,
+      "Invalid character(s). Please refer to the name guidelines."
     ),
   description: yup.string().label("Description"),
 });

--- a/schemas/policy-group-form.js
+++ b/schemas/policy-group-form.js
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-import React from "react";
-import PropTypes from "prop-types";
-import styles from "styles/modules/Header.module.scss";
+import * as yup from "yup";
 
-// TODO: create pageHeader in typography, share between pages
-
-const PageHeader = ({ children }) => {
-  return <div className={styles.pageHeader}>{children}</div>;
-};
-
-PageHeader.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.string,
-    PropTypes.func,
-  ]).isRequired,
-};
-
-export default PageHeader;
+export const schema = yup.object().shape({
+  name: yup.string().required().label("Policy Group Name").matches(/^([a-z]*|\d*|[-_]*)*$/g, "Invalid character(s). Please refer to name guidelines."),
+  description: yup.string().label("Description"),
+});

--- a/styles/modules/Header.module.scss
+++ b/styles/modules/Header.module.scss
@@ -157,6 +157,15 @@ $DESKTOP_NAV_WIDTH: 30vw;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
+
+  > h1 {
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  > * {
+    margin-left: 0.75rem;
+  }
 }
 
 .darkTheme {
@@ -184,6 +193,12 @@ $DESKTOP_NAV_WIDTH: 30vw;
       border-bottom-color: $DT_LINK;
     }
   }
+
+  &.pageHeader {
+    > h1 {
+      color: $LAGOON;
+    }
+  }
 }
 
 .lightTheme {
@@ -209,6 +224,12 @@ $DESKTOP_NAV_WIDTH: 30vw;
     &:hover {
       @include transition;
       border-bottom-color: $LT_LINK;
+    }
+  }
+
+  &.pageHeader {
+    > h1 {
+      color: $DEEP_SEA;
     }
   }
 }

--- a/styles/modules/Playground.module.scss
+++ b/styles/modules/Playground.module.scss
@@ -200,11 +200,6 @@ $GAP: 1rem;
   }
 }
 
-.pageTitle {
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
 .instructions {
   display: none;
 
@@ -264,10 +259,6 @@ $GAP: 1rem;
 .darkTheme {
   &.pageContainer {
     background-color: $DT_BACKGROUND_LIGHT;
-  }
-
-  .pageTitle {
-    color: $LAGOON;
   }
 
   .instructions,
@@ -335,10 +326,6 @@ $GAP: 1rem;
 }
 
 .lightTheme {
-  .pageTitle {
-    color: $DEEP_SEA;
-  }
-
   .instructions,
   .selectToBeginText {
     color: $LT_SUB_TEXT;

--- a/styles/modules/Policy.module.scss
+++ b/styles/modules/Policy.module.scss
@@ -52,11 +52,6 @@
   }
 }
 
-.heading {
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
 .policyInputsContainer {
   margin-bottom: 1rem;
   padding: 1rem;
@@ -250,10 +245,6 @@
 }
 
 .darkTheme {
-  .heading {
-    color: $LAGOON;
-  }
-
   .policyInputsContainer {
     background-color: $DT_BACKGROUND_MEDIUM;
   }
@@ -282,10 +273,6 @@
 }
 
 .lightTheme {
-  .heading {
-    color: $DEEP_SEA;
-  }
-
   .policyInputsContainer {
     background-color: $LT_BACKGROUND_LIGHT;
   }

--- a/styles/modules/PolicyGroupDashboard.module.scss
+++ b/styles/modules/PolicyGroupDashboard.module.scss
@@ -1,0 +1,68 @@
+@import "styles/constants";
+@import "styles/mixins";
+
+.pageHeader {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.createNewButton {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.policyGroupName {
+  font-size: 1.25rem;
+}
+
+.cardsContainer {
+  width: 95vw;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: auto;
+  grid-gap: 1rem;
+
+  @include tabletAndLarger {
+    grid-gap: 2rem;
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+.card {
+  min-height: 10rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+
+  > * {
+    text-align: center;
+  }
+}
+
+.darkTheme {
+  .policyGroupName {
+    color: $DT_LINK;
+  }
+
+  .card {
+    background-color: $DT_BACKGROUND_MEDIUM;
+    box-shadow: $DT_BOX_SHADOW;
+    color: $DT_MAIN_TEXT;
+  }
+}
+
+.lightTheme {
+
+  .policyGroupName {
+    color: $LT_LINK;
+  }
+
+  .card {
+    background-color: $LT_BACKGROUND_LIGHT;
+    box-shadow: $LT_BOX_SHADOW;
+    color: $LT_MAIN_TEXT;
+  }
+}

--- a/styles/modules/PolicyGroupDashboard.module.scss
+++ b/styles/modules/PolicyGroupDashboard.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @import "styles/constants";
 @import "styles/mixins";
 

--- a/styles/modules/PolicyGroupDashboard.module.scss
+++ b/styles/modules/PolicyGroupDashboard.module.scss
@@ -1,11 +1,6 @@
 @import "styles/constants";
 @import "styles/mixins";
 
-.pageHeader {
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
 .createNewButton {
   position: absolute;
   top: 1rem;

--- a/styles/modules/PolicyGroupDashboard.module.scss
+++ b/styles/modules/PolicyGroupDashboard.module.scss
@@ -55,7 +55,6 @@
 }
 
 .lightTheme {
-
   .policyGroupName {
     color: $LT_LINK;
   }

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @import "styles/constants";
 @import "styles/mixins";
 

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -1,9 +1,6 @@
 @import "styles/constants";
 @import "styles/mixins";
 
-// TODO: create form component?
-// TODO: align all form buttons to bottom of the page if applicable
-
 .pageContainer {
   display: flex;
   flex-direction: column;
@@ -17,11 +14,6 @@
     flex-direction: row;
     justify-content: space-between;
   }
-}
-
-.pageHeader {
-  font-size: 1.25rem;
-  font-weight: 600;
 }
 
 .hint {
@@ -100,10 +92,6 @@
 }
 
 .darkTheme {
-  .pageHeader {
-    color: $DT_LINK;
-  }
-
   .formContentContainer {
     background-color: $DT_BACKGROUND_MEDIUM;
   }
@@ -119,10 +107,6 @@
 }
 
 .lightTheme {
-  .pageHeader {
-    color: $LT_LINK;
-  }
-
   .formContentContainer {
     background-color: $LT_BACKGROUND_LIGHT;
   }

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -35,13 +35,31 @@
 .hint {
   font-size: 0.8rem;
   font-style: italic;
-  text-align: right;
-  margin-left: auto;
+  margin-left: 1rem;
+
+  &::before {
+    content: attr(spacing);
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 0 1rem;
+    visibility: hidden;
+  }
+
+  > span {
+    font-weight: 700;
+  }
 }
 
 .formNotes {
   flex: 1;
   margin: 0 1rem;
+  padding-left: 1rem;
+  border-left: solid 0.25rem transparent;
+
+  h2 {
+    font-weight: 600;
+    font-size: 1rem;
+  }
 
   > *:not(code) {
     margin: 0.25rem auto;
@@ -114,10 +132,21 @@
 
   .formNotes {
     color: $DT_SUB_TEXT;
+    border-left-color: $LAGOON;
+
+    h2 {
+      color: $DT_MAIN_TEXT;
+    }
 
     code {
       color: $DT_MAIN_TEXT;
       background-color: $DT_BACKGROUND_DARK;
+    }
+  }
+
+  .hint {
+    > span {
+      color: $LAGOON;
     }
   }
 }
@@ -129,10 +158,21 @@
 
   .formNotes {
     color: $LT_SUB_TEXT;
+    border-left-color: $DEEP_SEA;
+
+    h2 {
+      color: $LT_MAIN_TEXT;
+    }
 
     code {
       color: $LT_MAIN_TEXT;
       background-color: $LT_BACKGROUND_DARK;
+    }
+  }
+
+  .hint {
+    > span {
+      color: $DEEP_SEA;
     }
   }
 }

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -2,14 +2,21 @@
 @import "styles/mixins";
 
 // TODO: create form component?
+// TODO: align all form buttons to bottom of the page if applicable
 
 .pageContainer {
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  flex-direction: column;
+  justify-content: flex-start;
   align-items: flex-start;
   width: 95%;
+  height: 100%;
   margin: 0 auto;
+
+  @include tabletAndLarger {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 }
 
 .pageHeader {
@@ -52,7 +59,11 @@
 
 .form {
   flex: 3;
-
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .formContentContainer {
@@ -71,7 +82,7 @@
 }
 
 .buttonsContainer {
-  margin-top: 1rem;
+  margin: 1rem 0;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -1,0 +1,127 @@
+@import "styles/constants";
+@import "styles/mixins";
+
+// TODO: create form component?
+
+.pageContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 95%;
+  margin: 0 auto;
+}
+
+.pageHeader {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.hint {
+  font-size: 0.8rem;
+  font-style: italic;
+  text-align: right;
+  margin-left: auto;
+}
+
+.formNotes {
+  flex: 1;
+  margin: 0 1rem;
+
+  > *:not(code) {
+    margin: 0.25rem auto;
+  }
+
+  > div:not(div:first-of-type) {
+    margin-top: 1rem;
+  }
+
+  ul > li {
+    font-size: 0.9rem;
+    list-style-position: inside;
+  }
+
+  code {
+    font-size: 0.8rem;
+    display: block;
+    width: fit-content;
+    padding: 0.5rem;
+    margin: 0.25rem;
+  }
+}
+
+.form {
+  flex: 3;
+
+}
+
+.formContentContainer {
+  width: 100%;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+
+  > *:not(.hint) {
+    margin: 0.5rem auto 0;
+  }
+
+  @include tabletAndLarger {
+    padding: 2rem;
+  }
+}
+
+.buttonsContainer {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  @include tabletAndLarger {
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+  }
+
+  > button {
+    margin-right: 1rem;
+  }
+}
+
+.darkTheme {
+  .pageHeader {
+    color: $DT_LINK;
+  }
+
+  .formContentContainer {
+    background-color: $DT_BACKGROUND_MEDIUM;
+  }
+
+  .formNotes {
+    color: $DT_SUB_TEXT;
+
+    code {
+      color: $DT_MAIN_TEXT;
+      background-color: $DT_BACKGROUND_DARK;
+    }
+  }
+}
+
+.lightTheme {
+  .pageHeader {
+    color: $LT_LINK;
+  }
+
+  .formContentContainer {
+    background-color: $LT_BACKGROUND_LIGHT;
+  }
+
+  .formNotes {
+    color: $LT_SUB_TEXT;
+
+    code {
+      color: $LT_MAIN_TEXT;
+      background-color: $LT_BACKGROUND_DARK;
+    }
+  }
+}

--- a/test/components/layout/Header.spec.js
+++ b/test/components/layout/Header.spec.js
@@ -86,4 +86,13 @@ describe("Header", () => {
     expect(screen.getByText("Policy Playground")).toBeInTheDocument();
     expect(screen.getByText("Create New Policy")).toBeInTheDocument();
   });
+
+  it("should render the section and links for Admin", () => {
+    act(() => {
+      userEvent.click(screen.getByTitle(/menu/i));
+    });
+
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("Policy Groups")).toBeInTheDocument();
+  });
 });

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -120,7 +120,7 @@ describe("/api/policies", () => {
 
       it("should hit the Rode API", async () => {
         const expectedUrl = createExpectedUrl("http://localhost:50051", {
-          filter: `policy.name.contains("${filterParam}")`,
+          filter: `name.contains("${filterParam}")`,
         });
 
         await handler(request, response);

--- a/test/pages/api/policies.spec.js
+++ b/test/pages/api/policies.spec.js
@@ -16,7 +16,12 @@
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policies";
-import { get, post, getRodeUrl } from "pages/api/utils/api-utils";
+import {
+  get,
+  post,
+  getRodeUrl,
+  buildPaginationParams,
+} from "pages/api/utils/api-utils";
 import { mapToApiModel } from "pages/api/utils/policy-utils";
 
 jest.mock("node-fetch");
@@ -95,6 +100,7 @@ describe("/api/policies", () => {
         }),
         chance.d4()
       );
+      buildPaginationParams.mockReturnValue({});
 
       rodeResponse = {
         ok: true,
@@ -119,6 +125,7 @@ describe("/api/policies", () => {
 
         await handler(request, response);
 
+        expect(buildPaginationParams).toHaveBeenCalledWith(request);
         expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 
@@ -128,30 +135,7 @@ describe("/api/policies", () => {
         request.query.filter = null;
         await handler(request, response);
 
-        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-      });
-
-      it("should pass the pageSize as a query param when a pageSize is specified", async () => {
-        const pageSize = chance.d10();
-        const expectedUrl = createExpectedUrl("http://localhost:50051", {
-          filter: `policy.name.contains("${filterParam}")`,
-          pageSize,
-        });
-
-        request.query.pageSize = pageSize;
-        await handler(request, response);
-        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-      });
-
-      it("should pass the pageToken as a query param when a pageToken is specified", async () => {
-        const pageToken = chance.string();
-        const expectedUrl = createExpectedUrl("http://localhost:50051", {
-          filter: `policy.name.contains("${filterParam}")`,
-          pageToken,
-        });
-
-        request.query.pageToken = pageToken;
-        await handler(request, response);
+        expect(buildPaginationParams).toHaveBeenCalledWith(request);
         expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 

--- a/test/pages/api/policy-groups.spec.js
+++ b/test/pages/api/policy-groups.spec.js
@@ -16,7 +16,12 @@
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/policy-groups";
-import { get, post, getRodeUrl } from "pages/api/utils/api-utils";
+import {
+  get,
+  post,
+  getRodeUrl,
+  buildPaginationParams,
+} from "pages/api/utils/api-utils";
 
 jest.mock("node-fetch");
 jest.mock("pages/api/utils/api-utils");
@@ -35,6 +40,8 @@ describe("/api/policy-groups", () => {
       status: jest.fn().mockReturnThis(),
       json: jest.fn().mockReturnThis(),
     };
+
+    buildPaginationParams.mockReturnValue({});
 
     getRodeUrl.mockReturnValue("http://localhost:50051");
   });
@@ -111,6 +118,9 @@ describe("/api/policy-groups", () => {
 
         await handler(request, response);
 
+        expect(buildPaginationParams)
+          .toHaveBeenCalledTimes(1)
+          .toHaveBeenCalledWith(request);
         expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 
@@ -122,28 +132,9 @@ describe("/api/policy-groups", () => {
 
         request.query.filter = filter;
         await handler(request, response);
-        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-      });
-
-      it("should pass the pageSize as a query param when a pageSize is specified", async () => {
-        const pageSize = chance.d10();
-        const expectedUrl = createExpectedUrl("http://localhost:50051", {
-          pageSize,
-        });
-
-        request.query.pageSize = pageSize;
-        await handler(request, response);
-        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-      });
-
-      it("should pass the pageToken as a query param when a pageToken is specified", async () => {
-        const pageToken = chance.string();
-        const expectedUrl = createExpectedUrl("http://localhost:50051", {
-          pageToken,
-        });
-
-        request.query.pageToken = pageToken;
-        await handler(request, response);
+        expect(buildPaginationParams)
+          .toHaveBeenCalledTimes(1)
+          .toHaveBeenCalledWith(request);
         expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
       });
 

--- a/test/pages/api/policy-groups.spec.js
+++ b/test/pages/api/policy-groups.spec.js
@@ -1,0 +1,270 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StatusCodes, ReasonPhrases } from "http-status-codes";
+import handler from "pages/api/policy-groups";
+import { get, post, getRodeUrl } from "pages/api/utils/api-utils";
+
+jest.mock("node-fetch");
+jest.mock("pages/api/utils/api-utils");
+
+describe("/api/policy-groups", () => {
+  let request, response, rodeResponse;
+
+  beforeEach(() => {
+    request = {
+      method: chance.pickone(["GET", "POST"]),
+      query: {},
+      body: {},
+    };
+
+    response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    getRodeUrl.mockReturnValue("http://localhost:50051");
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const assertInternalServerError = () => {
+    expect(response.status)
+      .toBeCalledTimes(1)
+      .toHaveBeenCalledWith(StatusCodes.INTERNAL_SERVER_ERROR);
+
+    expect(response.json)
+      .toHaveBeenCalledTimes(1)
+      .toHaveBeenCalledWith({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
+  };
+
+  describe("unimplemented methods", () => {
+    it("should return method not allowed", async () => {
+      request.method = chance.word();
+
+      await handler(request, response);
+
+      expect(response.status)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(StatusCodes.METHOD_NOT_ALLOWED);
+
+      expect(response.json)
+        .toBeCalledTimes(1)
+        .toHaveBeenCalledWith({ error: ReasonPhrases.METHOD_NOT_ALLOWED });
+    });
+  });
+
+  describe("GET", () => {
+    let policyGroups, pageToken;
+
+    beforeEach(() => {
+      request = {
+        method: "GET",
+        query: {},
+      };
+      pageToken = chance.string();
+
+      policyGroups = chance.n(
+        () => ({
+          [chance.word()]: chance.word(),
+          name: chance.name(),
+          description: chance.sentence(),
+        }),
+        chance.d4()
+      );
+
+      rodeResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          policyGroups: policyGroups,
+          nextPageToken: pageToken,
+        }),
+      };
+
+      get.mockResolvedValue(rodeResponse);
+    });
+
+    describe("successful call to Rode", () => {
+      const createExpectedUrl = (baseUrl, query = {}) => {
+        return `${baseUrl}/v1alpha1/policy-groups?${new URLSearchParams(
+          query
+        )}`;
+      };
+
+      it("should hit the Rode API", async () => {
+        const expectedUrl = createExpectedUrl("http://localhost:50051");
+
+        await handler(request, response);
+
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
+      });
+
+      it("should pass the filter as a query param when a filter is specified", async () => {
+        const filter = chance.string();
+        const expectedUrl = createExpectedUrl("http://localhost:50051", {
+          filter,
+        });
+
+        request.query.filter = filter;
+        await handler(request, response);
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
+      });
+
+      it("should pass the pageSize as a query param when a pageSize is specified", async () => {
+        const pageSize = chance.d10();
+        const expectedUrl = createExpectedUrl("http://localhost:50051", {
+          pageSize,
+        });
+
+        request.query.pageSize = pageSize;
+        await handler(request, response);
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
+      });
+
+      it("should pass the pageToken as a query param when a pageToken is specified", async () => {
+        const pageToken = chance.string();
+        const expectedUrl = createExpectedUrl("http://localhost:50051", {
+          pageToken,
+        });
+
+        request.query.pageToken = pageToken;
+        await handler(request, response);
+        expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
+      });
+
+      it("should return the policy groups", async () => {
+        await handler(request, response);
+
+        expect(response.status)
+          .toHaveBeenCalledTimes(1)
+          .toHaveBeenCalledWith(StatusCodes.OK);
+
+        expect(response.json).toHaveBeenCalledTimes(1).toHaveBeenCalledWith({
+          data: policyGroups,
+          pageToken,
+        });
+      });
+    });
+
+    describe("failed calls to Rode", () => {
+      it("should return an internal server error on a non-200 response from Rode", async () => {
+        rodeResponse.ok = false;
+
+        await handler(request, response);
+
+        assertInternalServerError();
+      });
+
+      it("should return an internal server error on a network or other fetch error", async () => {
+        get.mockRejectedValue(new Error());
+
+        await handler(request, response);
+
+        assertInternalServerError();
+      });
+
+      it("should return an internal server error when JSON is invalid", async () => {
+        rodeResponse.json.mockRejectedValue(new Error());
+
+        await handler(request, response);
+
+        assertInternalServerError();
+      });
+    });
+  });
+
+  describe("POST", () => {
+    let formData, createdPolicyGroup;
+
+    beforeEach(() => {
+      formData = {
+        [chance.string()]: chance.string(),
+      };
+      request = {
+        method: "POST",
+        body: JSON.stringify(formData),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      };
+
+      createdPolicyGroup = {
+        name: chance.string(),
+        description: chance.sentence(),
+      };
+
+      rodeResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue(createdPolicyGroup),
+      };
+
+      post.mockResolvedValue(rodeResponse);
+    });
+
+    describe("successful call to Rode", () => {
+      it("should hit the Rode API", async () => {
+        await handler(request, response);
+
+        expect(post)
+          .toHaveBeenCalledTimes(1)
+          .toHaveBeenCalledWith(
+            "http://localhost:50051/v1alpha1/policy-groups",
+            request.body
+          );
+      });
+
+      it("should return the created policy group", async () => {
+        await handler(request, response);
+
+        expect(response.status)
+          .toHaveBeenCalledTimes(1)
+          .toHaveBeenCalledWith(StatusCodes.OK);
+
+        expect(response.json)
+          .toHaveBeenCalledTimes(1)
+          .toHaveBeenCalledWith(createdPolicyGroup);
+      });
+    });
+
+    describe("failed calls to Rode", () => {
+      it("should return an internal server error on a non-200 response from Rode", async () => {
+        rodeResponse.ok = false;
+
+        await handler(request, response);
+
+        assertInternalServerError();
+      });
+
+      it("should return an internal server error on a network or other fetch error", async () => {
+        post.mockRejectedValue(new Error());
+
+        await handler(request, response);
+
+        assertInternalServerError();
+      });
+
+      it("should return an internal server error when JSON is invalid", async () => {
+        rodeResponse.json.mockRejectedValue(new Error());
+
+        await handler(request, response);
+
+        assertInternalServerError();
+      });
+    });
+  });
+});

--- a/test/pages/api/resource-versions.spec.js
+++ b/test/pages/api/resource-versions.spec.js
@@ -104,7 +104,7 @@ describe("/api/resource-versions", () => {
 
   describe("successful call to Rode", () => {
     const createExpectedUrl = (query = {}) => {
-      return `${rodeUrl}/v1alpha1/generic-resource-versions?${new URLSearchParams(
+      return `${rodeUrl}/v1alpha1/resource-versions?${new URLSearchParams(
         query
       )}`;
     };

--- a/test/pages/api/resource-versions.spec.js
+++ b/test/pages/api/resource-versions.spec.js
@@ -16,7 +16,11 @@
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/resource-versions";
-import { getRodeUrl, get } from "pages/api/utils/api-utils";
+import {
+  getRodeUrl,
+  get,
+  buildPaginationParams,
+} from "pages/api/utils/api-utils";
 
 jest.mock("pages/api/utils/api-utils");
 
@@ -63,6 +67,7 @@ describe("/api/resource-versions", () => {
     rodeUrl = chance.url();
 
     getRodeUrl.mockReturnValue(rodeUrl);
+    buildPaginationParams.mockReturnValue({});
 
     get.mockResolvedValue(rodeResponse);
   });
@@ -116,6 +121,9 @@ describe("/api/resource-versions", () => {
 
       await handler(request, response);
 
+      expect(buildPaginationParams)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(request);
       expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
     });
 
@@ -128,30 +136,10 @@ describe("/api/resource-versions", () => {
 
       request.query.filter = filter;
       await handler(request, response);
-      expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-    });
 
-    it("should pass the pageSize as a query param when a pageSize is specified", async () => {
-      const pageSize = chance.d10();
-      const expectedUrl = createExpectedUrl({
-        id: resourceId,
-        pageSize,
-      });
-
-      request.query.pageSize = pageSize;
-      await handler(request, response);
-      expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-    });
-
-    it("should pass the pageToken as a query param when a pageToken is specified", async () => {
-      const pageToken = chance.string();
-      const expectedUrl = createExpectedUrl({
-        id: resourceId,
-        pageToken,
-      });
-
-      request.query.pageToken = pageToken;
-      await handler(request, response);
+      expect(buildPaginationParams)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(request);
       expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
     });
 

--- a/test/pages/api/resources.spec.js
+++ b/test/pages/api/resources.spec.js
@@ -16,7 +16,11 @@
 
 import { StatusCodes, ReasonPhrases } from "http-status-codes";
 import handler from "pages/api/resources";
-import { getRodeUrl, get } from "pages/api/utils/api-utils";
+import {
+  getRodeUrl,
+  get,
+  buildPaginationParams,
+} from "pages/api/utils/api-utils";
 
 jest.mock("pages/api/utils/api-utils");
 
@@ -65,6 +69,7 @@ describe("/api/resources", () => {
     };
 
     rodeUrl = chance.url();
+    buildPaginationParams.mockReturnValue({});
     getRodeUrl.mockReturnValue(rodeUrl);
 
     get.mockResolvedValue(rodeResponse);
@@ -102,6 +107,9 @@ describe("/api/resources", () => {
 
       await handler(request, response);
 
+      expect(buildPaginationParams)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(request);
       expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
     });
 
@@ -118,6 +126,9 @@ describe("/api/resources", () => {
 
       await handler(request, response);
 
+      expect(buildPaginationParams)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(request);
       expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
     });
 
@@ -133,6 +144,9 @@ describe("/api/resources", () => {
 
       await handler(request, response);
 
+      expect(buildPaginationParams)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(request);
       expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
     });
 
@@ -143,30 +157,9 @@ describe("/api/resources", () => {
       request.query.resourceTypes = null;
       await handler(request, response);
 
-      expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-    });
-
-    it("should pass the pageSize as a query param when a pageSize is specified", async () => {
-      const pageSize = chance.d10();
-      const expectedUrl = createExpectedUrl({
-        filter: `name.contains("${searchTerm}")`,
-        pageSize,
-      });
-
-      request.query.pageSize = pageSize;
-      await handler(request, response);
-      expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
-    });
-
-    it("should pass the pageToken as a query param when a pageToken is specified", async () => {
-      const pageToken = chance.string();
-      const expectedUrl = createExpectedUrl({
-        filter: `name.contains("${searchTerm}")`,
-        pageToken,
-      });
-
-      request.query.pageToken = pageToken;
-      await handler(request, response);
+      expect(buildPaginationParams)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith(request);
       expect(get).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedUrl);
     });
 

--- a/test/pages/api/resources.spec.js
+++ b/test/pages/api/resources.spec.js
@@ -59,7 +59,7 @@ describe("/api/resources", () => {
     rodeResponse = {
       ok: true,
       json: jest.fn().mockResolvedValue({
-        genericResources: allResources,
+        resources: allResources,
         nextPageToken: pageToken,
       }),
     };
@@ -92,9 +92,7 @@ describe("/api/resources", () => {
 
   describe("successful call to Rode", () => {
     const createExpectedUrl = (query = {}) => {
-      return `${rodeUrl}/v1alpha1/generic-resources?${new URLSearchParams(
-        query
-      )}`;
+      return `${rodeUrl}/v1alpha1/resources?${new URLSearchParams(query)}`;
     };
 
     it("should pass the correct params for a specified search term", async () => {

--- a/test/pages/api/resources.spec.js
+++ b/test/pages/api/resources.spec.js
@@ -120,7 +120,7 @@ describe("/api/resources", () => {
       const expectedUrl = createExpectedUrl({
         filter: resourceTypes
           .split(",")
-          .map((type) => `"type"=="${type}"`)
+          .map((type) => `type=="${type}"`)
           .join("||"),
       });
 
@@ -138,7 +138,7 @@ describe("/api/resources", () => {
       const expectedUrl = createExpectedUrl({
         filter: `name.contains("${searchTerm}")&&(${resourceTypes
           .split(",")
-          .map((type) => `"type"=="${type}"`)
+          .map((type) => `type=="${type}"`)
           .join("||")})`,
       });
 

--- a/test/pages/api/utils/api-utils.spec.js
+++ b/test/pages/api/utils/api-utils.spec.js
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { getRodeUrl, post, patch, get, del } from "pages/api/utils/api-utils";
+import {
+  getRodeUrl,
+  post,
+  patch,
+  get,
+  del,
+  buildPaginationParams,
+} from "pages/api/utils/api-utils";
 import fetch from "node-fetch";
 
 jest.mock("node-fetch");
@@ -117,6 +124,32 @@ describe("api-utils", () => {
 
       expect(fetch).toHaveBeenCalledWith(endpoint, {
         method: "DELETE",
+      });
+    });
+  });
+
+  describe("buildPaginationParams", () => {
+    let request;
+
+    beforeEach(() => {
+      request = {
+        query: {},
+      };
+    });
+
+    it("should return the pageSize param when it is present in the request", () => {
+      request.query.pageSize = chance.d100();
+      const actual = buildPaginationParams(request);
+      expect(actual).toEqual({
+        pageSize: request.query.pageSize,
+      });
+    });
+
+    it("should return the pageToken param when it is present in the request", () => {
+      request.query.pageToken = chance.string();
+      const actual = buildPaginationParams(request);
+      expect(actual).toEqual({
+        pageToken: request.query.pageToken,
       });
     });
   });

--- a/test/pages/policy-groups.spec.js
+++ b/test/pages/policy-groups.spec.js
@@ -91,6 +91,15 @@ describe("Policy Groups", () => {
     });
   });
 
+  it("should render the card with no description if it is not present", () => {
+    mockPaginatedFetchResponse.data[0].description = "";
+    rerender(<PolicyGroups />);
+    const renderedName = screen.getByText(
+      mockPaginatedFetchResponse.data[0].name
+    );
+    expect(renderedName.closest("div").children).toHaveLength(1);
+  });
+
   it("should render the button to view more if there are multiple pages of results", () => {
     mockPaginatedFetchResponse.isLastPage = false;
     rerender(<PolicyGroups />);

--- a/test/pages/policy-groups.spec.js
+++ b/test/pages/policy-groups.spec.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { useRouter } from "next/router";
+import { usePaginatedFetch } from "hooks/usePaginatedFetch";
+import userEvent from "@testing-library/user-event";
+import PolicyGroups from "pages/policy-groups";
+
+jest.mock("next/router");
+jest.mock("hooks/usePaginatedFetch");
+
+describe("Policy Groups", () => {
+  let router, policyGroups, mockPaginatedFetchResponse, rerender;
+  beforeEach(() => {
+    policyGroups = chance.n(
+      () => ({
+        name: chance.string(),
+        description: chance.string(),
+      }),
+      chance.d4()
+    );
+    mockPaginatedFetchResponse = {
+      data: policyGroups,
+      loading: false,
+      isLastPage: chance.bool(),
+      goToNextPage: jest.fn(),
+    };
+    router = {
+      query: {},
+      push: jest.fn(),
+    };
+    useRouter.mockReturnValue(router);
+
+    usePaginatedFetch.mockReturnValue(mockPaginatedFetchResponse);
+    const utils = render(<PolicyGroups />);
+    rerender = utils.rerender;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should render the page header", () => {
+    const renderedHeader = screen.getByText(/^manage policy groups$/i);
+    expect(renderedHeader).toBeInTheDocument();
+  });
+
+  it("should render a button to create a new policy group", () => {
+    const renderedButton = screen.getByText(/^create new policy group$/i);
+    expect(renderedButton).toBeInTheDocument();
+    userEvent.click(renderedButton);
+    expect(router.push)
+      .toHaveBeenCalledTimes(1)
+      .toHaveBeenCalledWith("/policy-groups/new");
+  });
+
+  it("should call to fetch the policy groups", () => {
+    expect(usePaginatedFetch).toHaveBeenCalledWith(
+      "/api/policy-groups",
+      {},
+      100
+    );
+  });
+
+  it("should render the loading indicator while fetching data", () => {
+    mockPaginatedFetchResponse.loading = true;
+    rerender(<PolicyGroups />);
+
+    expect(screen.getByTestId("loadingIndicator")).toBeInTheDocument();
+  });
+
+  it("should render a card for each policy group found", () => {
+    mockPaginatedFetchResponse.data.forEach((group) => {
+      expect(screen.getByText(group.name)).toBeInTheDocument();
+      expect(screen.getByText(group.description)).toBeInTheDocument();
+    });
+  });
+
+  it("should render the button to view more if there are multiple pages of results", () => {
+    mockPaginatedFetchResponse.isLastPage = false;
+    rerender(<PolicyGroups />);
+
+    const renderedButton = screen.getByText("View More");
+    expect(renderedButton).toBeInTheDocument;
+    userEvent.click(renderedButton);
+    expect(mockPaginatedFetchResponse.goToNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the no policy groups found message if no groups are found", () => {
+    mockPaginatedFetchResponse.data = [];
+    rerender(<PolicyGroups />);
+
+    expect(screen.getByText(/no policy groups exist./i)).toBeInTheDocument();
+  });
+});

--- a/test/pages/policy-groups/new.spec.js
+++ b/test/pages/policy-groups/new.spec.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render, screen, act } from "test/testing-utils/renderer";
+
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/router";
+import { useFormValidation } from "hooks/useFormValidation";
+import { showError } from "utils/toast-utils";
+import CreateNewPolicyGroup from "pages/policy-groups/new";
+
+jest.mock("next/router");
+jest.mock("utils/toast-utils");
+jest.mock("hooks/useFormValidation");
+
+describe("New Policy Group", () => {
+  let router,
+    fetchResponse,
+    createdPolicyGroup,
+    isValid,
+    validationErrors,
+    validateField,
+    rerender;
+
+  beforeEach(() => {
+    router = {
+      back: jest.fn(),
+      push: jest.fn().mockResolvedValue({}),
+    };
+    createdPolicyGroup = {
+      [chance.string()]: chance.string(),
+      name: chance.string({ alpha: true, casing: "lower" }),
+      description: chance.string(),
+    };
+    fetchResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue(createdPolicyGroup),
+    };
+    isValid = jest.fn().mockReturnValue(true);
+    validateField = jest.fn().mockReturnValue({});
+    validationErrors = {};
+    useFormValidation.mockReturnValue({
+      isValid,
+      errors: validationErrors,
+      validateField,
+    });
+    useRouter.mockReturnValue(router);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn().mockResolvedValue(fetchResponse);
+    const utils = render(<CreateNewPolicyGroup />);
+    rerender = utils.rerender;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should render the name input", () => {
+    const input = screen.getByLabelText(/name/i);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("should render the description input", () => {
+    const input = screen.getByLabelText(/description/i);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("should render the save button for the form", () => {
+    const saveButton = screen.getByText(/Save Policy Group/i);
+    expect(saveButton).toBeInTheDocument();
+  });
+
+  it("should render the cancel button", () => {
+    const cancelButton = screen.getByText(/cancel/i);
+    expect(cancelButton).toBeInTheDocument();
+
+    userEvent.click(cancelButton);
+    expect(router.back).toHaveBeenCalledTimes(1);
+  });
+
+  describe("successful save", () => {
+    let formData;
+
+    beforeEach(async () => {
+      formData = {
+        name: chance.string({ alpha: true, casing: "lower" }),
+        description: chance.sentence(),
+      };
+
+      userEvent.type(screen.getByLabelText(/name/i), formData.name);
+      userEvent.type(
+        screen.getByLabelText(/description/i),
+        formData.description
+      );
+
+      await act(async () => {
+        await userEvent.click(screen.getByText(/save policy group/i));
+      });
+    });
+
+    it("should call to validate the form", () => {
+      expect(isValid).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(formData);
+    });
+
+    it("should submit the form when filled out entirely", () => {
+      expect(fetch)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith("/api/policy-groups", {
+          method: "POST",
+          body: JSON.stringify(formData),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+    });
+
+    it("should redirect the user to the policy group dashboard", () => {
+      expect(router.push)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith("/policy-groups");
+    });
+  });
+
+  describe("unsuccessful save", () => {
+    it("should show a validation error when a required field is not filled out", async () => {
+      isValid.mockReturnValue(false);
+      validationErrors.name = chance.string();
+      await userEvent.click(screen.getByText(/save policy group/i));
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(router.push).not.toHaveBeenCalled();
+
+      rerender(<CreateNewPolicyGroup />);
+      expect(screen.getByText(validationErrors.name)).toBeInTheDocument();
+      userEvent.click(screen.getByLabelText(/policy group name/i));
+      userEvent.tab();
+
+      expect(validateField).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show an error when the call to create failed", async () => {
+      fetchResponse.ok = false;
+      await act(async () => {
+        await userEvent.click(screen.getByText(/save policy group/i));
+      });
+
+      expect(showError)
+        .toHaveBeenCalledTimes(1)
+        .toHaveBeenCalledWith("Failed to create the policy group.");
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(router.push).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
* Adds screens and functionality for creating new policy group and viewing all groups in a dashboard
* Refactors some of the pagination parameter building on the api
* Refactors some styles that were duplicated across multiple page headers

Closes #117 