### PR TITLE
Delete Policy Group

### DIFF
--- a/components/policy-groups/PolicyGroupForm.js
+++ b/components/policy-groups/PolicyGroupForm.js
@@ -24,7 +24,7 @@ import styles from "styles/modules/PolicyGroupForm.module.scss";
 import PageHeader from "components/layout/PageHeader";
 import { useFormValidation } from "hooks/useFormValidation";
 import { schema } from "schemas/policy-group-form";
-import { showError } from "utils/toast-utils";
+import { showError, showSuccess } from "utils/toast-utils";
 import { stateActions } from "reducers/appState";
 import { useAppState } from "providers/appState";
 import { StatusCodes } from "http-status-codes";
@@ -90,7 +90,25 @@ const PolicyGroupForm = (props) => {
     router.push(`/policy-groups/${formData.name}`);
   };
 
-  // TODO: add delete
+  const onDelete = async (event) => {
+    event.preventDefault();
+
+    setLoading(true);
+    const response = await fetch(`/api/policy-groups/${policyGroup.name}`, {
+      method: "DELETE",
+    });
+    setLoading(false);
+
+    if (!response.ok) {
+      showError(
+        "An error occurred while deleting the policy group. Please try again."
+      );
+      return;
+    }
+
+    showSuccess("Policy group was successfully deleted.");
+    router.push("/policy-groups");
+  };
 
   return (
     <>
@@ -136,18 +154,30 @@ const PolicyGroupForm = (props) => {
             />
           </div>
           <div className={styles.buttonsContainer}>
-            <Button
-              label={submitButtonText}
-              type={"submit"}
-              loading={loading}
-            />
+            <div className={styles.primaryButtonsContainer}>
+              <Button
+                label={submitButtonText}
+                type={"submit"}
+                loading={loading}
+              />
 
-            <Button
-              label={"Cancel"}
-              onClick={() => router.back()}
-              buttonType={"text"}
-              disabled={loading}
-            />
+              <Button
+                label={"Cancel"}
+                onClick={() => router.back()}
+                buttonType={"text"}
+                disabled={loading}
+              />
+            </div>
+            {!creatingNewPolicyGroup && (
+              <div>
+                <Button
+                  label={"Delete Policy Group"}
+                  onClick={onDelete}
+                  buttonType={"textDestructive"}
+                  disabled={loading}
+                />
+              </div>
+            )}
           </div>
         </form>
         <div

--- a/cypress/integration/Policy.feature
+++ b/cypress/integration/Policy.feature
@@ -63,7 +63,6 @@ Feature: Policies
       | field   |
       | name        |
       | description |
-      | regoContent |
 
   Scenario: Edit policy - invalid rego
     Given I am on the "Existing" policy details page

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -114,6 +114,18 @@
 }
 
 .buttonsContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  @include tabletAndLarger {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+.primaryButtonsContainer {
   margin: 1rem 0;
   display: flex;
   flex-direction: column;
@@ -123,7 +135,6 @@
   @include tabletAndLarger {
     flex-direction: row;
     justify-content: flex-start;
-    align-items: center;
   }
 
   > button {

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -126,13 +126,13 @@
 }
 
 .primaryButtonsContainer {
-  margin: 1rem 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
 
   @include tabletAndLarger {
+    margin: 1rem 0;
     flex-direction: row;
     justify-content: flex-start;
   }


### PR DESCRIPTION
Closes #121 

Super simple delete functionality. Since there's no assignments yet, there is no prompt to confirm your choice to delete.


Once policy assignment is happening in the UI, I'll update this flow to include a confirmation and notice that there are X policies assigned to the policy group.