### PR TITLE
Typography

### DIFF
--- a/components/CodeEditor.js
+++ b/components/CodeEditor.js
@@ -20,6 +20,7 @@ import styles from "styles/modules/Inputs.module.scss";
 import { useTheme } from "providers/theme";
 import Editor from "react-simple-code-editor";
 import Prism from "prism/prism";
+import Text from "components/Text";
 
 const CodeEditor = (props) => {
   const {
@@ -38,18 +39,18 @@ const CodeEditor = (props) => {
   const highlightWithLineNumbers = (input) =>
     Prism.highlight(input, Prism.languages.rego)
       .split("\n")
-      .map((line, i) => `<span class='line-numbers'>${i + 1}</span>${line}`)
+      .map((line, i) => `<span class="line-numbers">${i + 1}</span>${line}`)
       .join("\n");
 
   return (
     <div className={styles.outerWrapper}>
       <div className={`${styles[theme]} ${styles.container}`}>
-        <label
+        <Text.Label
           htmlFor={name}
           className={`${styles.label} ${required ? "required" : ""}`}
         >
           {label}
-        </label>
+        </Text.Label>
         <Editor
           name={name}
           textareaId={name}

--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -19,6 +19,7 @@ import PropTypes from "prop-types";
 import styles from "styles/modules/Inputs.module.scss";
 import { useTheme } from "providers/theme";
 import Select from "react-select";
+import Text from "components/Text";
 
 const Dropdown = (props) => {
   const {
@@ -37,12 +38,12 @@ const Dropdown = (props) => {
   return (
     <div className={styles.outerWrapper}>
       <div className={`${styles[theme]} ${styles.container}`}>
-        <label
+        <Text.Label
           htmlFor={name}
           className={`${styles.label} ${required ? "required" : ""}`}
         >
           {label}
-        </label>
+        </Text.Label>
         <Select
           name={name}
           inputId={name}

--- a/components/ExternalLink.js
+++ b/components/ExternalLink.js
@@ -19,10 +19,9 @@ import PropTypes from "prop-types";
 import { ICON_NAMES } from "utils/icon-utils";
 import Icon from "./Icon";
 import styles from "styles/modules/Typography.module.scss";
-import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const ExternalLink = (props) => {
-  const { theme } = useTheme();
   const { href, label, className = "", fallback = null } = props;
 
   if (!href) {
@@ -30,15 +29,16 @@ const ExternalLink = (props) => {
   }
 
   return (
-    <a
-      className={`${styles[theme]} ${styles.externalLink} ${className}`}
+    <Text.Body1
+      as={"a"}
+      className={`${styles.externalLink} ${className}`}
       href={href}
       target="_blank"
       rel="noreferrer"
     >
       {label}
       <Icon name={ICON_NAMES.EXTERNAL_LINK} size={"small"} />
-    </a>
+    </Text.Body1>
   );
 };
 

--- a/components/Input.js
+++ b/components/Input.js
@@ -18,6 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Inputs.module.scss";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const Input = (props) => {
   const {
@@ -41,12 +42,12 @@ const Input = (props) => {
           horizontal ? styles.horizontalContainer : styles.container
         }`}
       >
-        <label
+        <Text.Label
           htmlFor={name}
           className={`${styles.label} ${required ? "required" : ""}`}
         >
           {label}
-        </label>
+        </Text.Label>
         <input
           type={type || "text"}
           name={name}

--- a/components/LabelWithValue.js
+++ b/components/LabelWithValue.js
@@ -17,6 +17,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Typography.module.scss";
+import Text from "components/Text";
 
 const LabelWithValue = (props) => {
   const { label, value, vertical = false, className = "", as = "p" } = props;
@@ -25,19 +26,19 @@ const LabelWithValue = (props) => {
     return null;
   }
 
-  const Text = as;
+  const Tag = as;
 
   return (
-    <Text
+    <Tag
       className={` ${
         vertical
           ? styles.verticalLabelWithValueContainer
           : styles.labelWithValueContainer
       } ${className}`}
     >
-      {label && <span className={styles.label}>{label}</span>}
-      <span className={styles.value}>{value}</span>
-    </Text>
+      <Text.Body1 as={"span"}>{label}</Text.Body1>
+      <Text.Value>{value}</Text.Value>
+    </Tag>
   );
 };
 

--- a/components/Modal.js
+++ b/components/Modal.js
@@ -22,6 +22,7 @@ import Button from "./Button";
 import Icon from "./Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import { useSafeLayoutEffect } from "hooks/useSafeLayoutEffect";
+import Text from "components/Text";
 
 const Modal = (props) => {
   const { title, children, onClose, isVisible } = props;
@@ -53,9 +54,9 @@ const Modal = (props) => {
         <Icon name={ICON_NAMES.X_CIRCLE} size="xlarge" />
       </Button>
       <div className={styles.contentWrapper}>
-        <h1 id={"modalTitle"} className={styles.title}>
+        <Text.Heading1 id={"modalTitle"} className={styles.title}>
           {title}
-        </h1>
+        </Text.Heading1>
         <div className={styles.content}>{children}</div>
       </div>
     </div>

--- a/components/Text.js
+++ b/components/Text.js
@@ -53,9 +53,13 @@ BaseText.propTypes = {
     "span",
     "p",
     "label",
+    "a",
   ]),
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
-    .isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]).isRequired,
   style: PropTypes.oneOf([
     "heading1",
     "heading2",

--- a/components/Text.js
+++ b/components/Text.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import styles from "styles/modules/Typography.module.scss";
+import { useTheme } from "providers/theme";
+
+// TODO: test this
+
+const BaseText = (props) => {
+  const { className = "", as = "p", style, children, ...otherProps } = props;
+  const { theme } = useTheme();
+
+  if (!children) {
+    return null;
+  }
+
+  const Tag = as;
+
+  return (
+    <Tag
+      className={`${styles[style]} ${styles[theme]} ${className}`}
+      {...otherProps}
+    >
+      {children}
+    </Tag>
+  );
+};
+
+BaseText.propTypes = {
+  className: PropTypes.string,
+  as: PropTypes.oneOf([
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "span",
+    "p",
+    "label",
+  ]),
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+    .isRequired,
+  style: PropTypes.oneOf([
+    "heading1",
+    "heading2",
+    "heading3",
+    "label",
+    "value",
+    "body1",
+    "body2",
+    "caption",
+    "button",
+  ]).isRequired,
+};
+
+/* eslint-disable react/prop-types */
+
+const Heading1 = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"h1"} style={"heading1"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+const Heading2 = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"h2"} style={"heading2"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+const Heading3 = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"h3"} style={"heading3"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+const Body1 = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"p"} style={"body1"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+const Body2 = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"p"} style={"body2"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+const Caption = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"span"} style={"caption"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+const Label = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"label"} style={"label"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+const Value = ({ children, ...otherProps }) => {
+  return (
+    <BaseText as={"span"} style={"value"} {...otherProps}>
+      {children}
+    </BaseText>
+  );
+};
+
+/* eslint-enable react/prop-types */
+
+const Text = {
+  Heading1,
+  Heading2,
+  Heading3,
+  Body1,
+  Body2,
+  Caption,
+  Label,
+  Value,
+};
+
+export default Text;

--- a/components/Text.js
+++ b/components/Text.js
@@ -19,10 +19,8 @@ import PropTypes from "prop-types";
 import styles from "styles/modules/Typography.module.scss";
 import { useTheme } from "providers/theme";
 
-// TODO: test this
-
 const BaseText = (props) => {
-  const { className = "", as = "p", style, children, ...otherProps } = props;
+  const { className = "", as, style, children, ...otherProps } = props;
   const { theme } = useTheme();
 
   if (!children) {
@@ -69,7 +67,6 @@ BaseText.propTypes = {
     "body1",
     "body2",
     "caption",
-    "button",
   ]).isRequired,
 };
 

--- a/components/TextArea.js
+++ b/components/TextArea.js
@@ -18,6 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Inputs.module.scss";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const TextArea = (props) => {
   const {
@@ -36,12 +37,12 @@ const TextArea = (props) => {
   return (
     <div className={styles.outerWrapper}>
       <div className={`${styles[theme]} ${styles.container}`}>
-        <label
+        <Text.Label
           htmlFor={name}
           className={`${styles.label} ${required ? "required" : ""}`}
         >
           {label}
-        </label>
+        </Text.Label>
         <textarea
           name={name}
           id={name}

--- a/components/layout/ThemeToggle.js
+++ b/components/layout/ThemeToggle.js
@@ -18,6 +18,7 @@ import React from "react";
 import styles from "styles/modules/Toggle.module.scss";
 import { useTheme } from "providers/theme";
 import { DARK_THEME } from "utils/constants";
+import Text from "components/Text";
 
 const ThemeToggle = () => {
   const { theme, toggleTheme } = useTheme();
@@ -25,7 +26,9 @@ const ThemeToggle = () => {
 
   return (
     <div className={`${styles.container} ${styles[theme]}`}>
-      <span id={"toggle-theme"}>Dark Mode: {isActive ? "ON" : "OFF"}</span>
+      <Text.Caption id={"toggle-theme"}>
+        Dark Mode: {isActive ? "ON" : "OFF"}
+      </Text.Caption>
       <button
         className={styles.toggle}
         onClick={toggleTheme}

--- a/components/occurrences/BuildOccurrenceDetails.js
+++ b/components/occurrences/BuildOccurrenceDetails.js
@@ -22,13 +22,13 @@ import dayjs from "dayjs";
 import ExternalLink from "components/ExternalLink";
 import OccurrenceCodeModal from "./OccurrenceCodeModal";
 import LabelWithValue from "components/LabelWithValue";
+import Text from "components/Text";
 
 const BuildOccurrenceDetails = ({ occurrence }) => {
   return (
     <div>
       <div className={styles.detailSummary}>
         <div>
-          <p className={styles.title}>Build</p>
           <ExternalLink
             href={occurrence.sourceUri}
             label={"View source"}
@@ -43,20 +43,22 @@ const BuildOccurrenceDetails = ({ occurrence }) => {
           <LabelWithValue label={"Created By"} value={occurrence.creator} />
         </div>
         <div className={styles.rightDetails}>
-          <p className={styles.timestamps}>
+          <Text.Body2 className={styles.timestamps}>
             Started {dayjs(occurrence.started).format(DATE_TIME_FORMAT)}
-          </p>
-          <p className={styles.timestamps}>
+          </Text.Body2>
+          <Text.Body2 className={styles.timestamps}>
             Completed {dayjs(occurrence.completed).format(DATE_TIME_FORMAT)}
-          </p>
+          </Text.Body2>
           <OccurrenceCodeModal json={occurrence.originals} />
         </div>
       </div>
       <div className={styles.detailContentContainer}>
         {occurrence.artifacts?.map((artifact) => (
           <div key={artifact.id} className={styles.card}>
-            <p className={styles.cardTitle}>Build Artifact</p>
-            <p>{artifact.id}</p>
+            <Text.Heading3 className={styles.cardTitle}>
+              Build Artifact
+            </Text.Heading3>
+            <Text.Body1>{artifact.id}</Text.Body1>
             <LabelWithValue
               label={"Related Artifact(s)"}
               value={artifact.names.join(", ")}

--- a/components/occurrences/BuildOccurrenceSection.js
+++ b/components/occurrences/BuildOccurrenceSection.js
@@ -26,6 +26,7 @@ import { DATE_TIME_FORMAT } from "utils/constants";
 import { getResourceDetails, RESOURCE_TYPES } from "utils/resource-utils";
 import LabelWithValue from "components/LabelWithValue";
 import ResourceVersion from "components/resources/ResourceVersion";
+import Text from "components/Text";
 
 const BuildOccurrenceSection = ({ occurrences, type }) => {
   if (!occurrences?.length) {
@@ -36,7 +37,7 @@ const BuildOccurrenceSection = ({ occurrences, type }) => {
     <div className={styles.sectionContainer}>
       <div className={styles.sectionTitle}>
         <Icon name={ICON_NAMES.COG} />
-        <p>Build</p>
+        <Text.Heading2>Build</Text.Heading2>
       </div>
       {occurrences.map((occurrence) => {
         let producedArtifactVersions = null;

--- a/components/occurrences/DeploymentOccurrenceDetails.js
+++ b/components/occurrences/DeploymentOccurrenceDetails.js
@@ -21,23 +21,23 @@ import { DATE_TIME_FORMAT } from "utils/constants";
 import dayjs from "dayjs";
 import OccurrenceCodeModal from "./OccurrenceCodeModal";
 import LabelWithValue from "components/LabelWithValue";
+import Text from "components/Text";
 
 const DeploymentOccurrenceDetails = ({ occurrence }) => {
   return (
     <div>
       <div className={styles.detailSummary}>
         <div>
-          <p className={styles.title}>Deployment</p>
-          <p>Deployed to {occurrence.platform}</p>
+          <Text.Body1>Deployed to {occurrence.platform}</Text.Body1>
         </div>
         <div className={styles.rightDetails}>
-          <p className={styles.timestamps}>
+          <Text.Body2 className={styles.timestamps}>
             Started {dayjs(occurrence.deploymentStart).format(DATE_TIME_FORMAT)}
-          </p>
-          <p className={styles.timestamps}>
+          </Text.Body2>
+          <Text.Body2 className={styles.timestamps}>
             Deployment End{" "}
             {dayjs(occurrence.deploymentEnd).format(DATE_TIME_FORMAT)}
-          </p>
+          </Text.Body2>
 
           <OccurrenceCodeModal json={occurrence.originals} />
         </div>

--- a/components/occurrences/DeploymentOccurrenceSection.js
+++ b/components/occurrences/DeploymentOccurrenceSection.js
@@ -22,6 +22,7 @@ import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import dayjs from "dayjs";
 import { DATE_TIME_FORMAT } from "utils/constants";
+import Text from "components/Text";
 
 const DeploymentOccurrenceSection = ({ occurrences }) => {
   if (!occurrences?.length) {
@@ -32,7 +33,7 @@ const DeploymentOccurrenceSection = ({ occurrences }) => {
     <div className={styles.sectionContainer}>
       <div className={styles.sectionTitle}>
         <Icon name={ICON_NAMES.SERVER} />
-        <p>Deploy</p>
+        <Text.Heading2>Deploy</Text.Heading2>
       </div>
       {occurrences.map((occurrence) => (
         <OccurrencePreview

--- a/components/occurrences/OccurrencePreview.js
+++ b/components/occurrences/OccurrencePreview.js
@@ -21,6 +21,7 @@ import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import { useAppState } from "providers/appState";
 import { stateActions } from "reducers/appState";
+import Text from "components/Text";
 
 const OccurrencePreview = ({
   mainText,
@@ -51,9 +52,9 @@ const OccurrencePreview = ({
       onClick={onClick}
     >
       <div className={styles.previewDetails}>
-        <p className={styles.previewMainText}>{mainText}</p>
-        <p className={styles.previewTimestamp}>{timestamp}</p>
-        <p className={styles.previewSubText}>{subText}</p>
+        <Text.Body1 className={styles.previewMainText}>{mainText}</Text.Body1>
+        <Text.Body2 className={styles.previewTimestamp}>{timestamp}</Text.Body2>
+        <Text.Body2 className={styles.previewSubText}>{subText}</Text.Body2>
       </div>
       <Icon
         name={

--- a/components/occurrences/OtherOccurrenceSection.js
+++ b/components/occurrences/OtherOccurrenceSection.js
@@ -22,6 +22,7 @@ import { ICON_NAMES } from "utils/icon-utils";
 import dayjs from "dayjs";
 import { DATE_TIME_FORMAT } from "utils/constants";
 import OccurrenceCodeModal from "./OccurrenceCodeModal";
+import Text from "components/Text";
 
 const OtherOccurrenceSection = ({ occurrences }) => {
   if (!occurrences?.length) {
@@ -32,15 +33,19 @@ const OtherOccurrenceSection = ({ occurrences }) => {
     <div className={styles.sectionContainer}>
       <div className={styles.sectionTitle}>
         <Icon name={ICON_NAMES.FLAG} />
-        <p>Other</p>
+        <Text.Heading2>Other</Text.Heading2>
       </div>
       {occurrences.map((occurrence) => (
         <div className={styles.unknownPreviewContainer} key={occurrence.name}>
-          <p className={styles.previewMainText}>{occurrence.kind}</p>
+          <Text.Body1 className={styles.previewMainText}>
+            {occurrence.kind}
+          </Text.Body1>
           {occurrence.createTime && (
-            <p className={styles.previewTimestamp}>{`Created at ${dayjs(
-              occurrence.createTime
-            ).format(DATE_TIME_FORMAT)}`}</p>
+            <Text.Body2
+              className={styles.previewTimestamp}
+            >{`Created at ${dayjs(occurrence.createTime).format(
+              DATE_TIME_FORMAT
+            )}`}</Text.Body2>
           )}
           <OccurrenceCodeModal json={occurrence} fullWidth={true} />
         </div>

--- a/components/occurrences/SecureOccurrenceSection.js
+++ b/components/occurrences/SecureOccurrenceSection.js
@@ -23,6 +23,7 @@ import { ICON_NAMES } from "utils/icon-utils";
 import { getVulnerabilityBreakdown } from "utils/occurrence-utils";
 import dayjs from "dayjs";
 import { DATE_TIME_FORMAT } from "utils/constants";
+import Text from "components/Text";
 
 const SecureOccurrenceSection = ({ occurrences }) => {
   if (!occurrences?.length) {
@@ -33,7 +34,7 @@ const SecureOccurrenceSection = ({ occurrences }) => {
     <div className={styles.sectionContainer}>
       <div className={styles.sectionTitle}>
         <Icon name={ICON_NAMES.SHIELD_CHECK} />
-        <p>Secure</p>
+        <Text.Heading2>Secure</Text.Heading2>
       </div>
       {occurrences.map((occurrence) => (
         <OccurrencePreview
@@ -50,13 +51,16 @@ const SecureOccurrenceSection = ({ occurrences }) => {
           subText={
             occurrence.completed ? (
               <>
-                <span>{`${occurrence.vulnerabilities.length} vulnerabilities found`}</span>
+                <Text.Body2
+                  as={"span"}
+                >{`${occurrence.vulnerabilities.length} vulnerabilities found`}</Text.Body2>
                 {!!occurrence.vulnerabilities.length && (
-                  <span
+                  <Text.Body2
                     className={styles.previewBreakdown}
+                    as={"span"}
                   >{`${getVulnerabilityBreakdown(
                     occurrence.vulnerabilities
-                  )}`}</span>
+                  )}`}</Text.Body2>
                 )}
               </>
             ) : null

--- a/components/occurrences/VulnerabilityCard.js
+++ b/components/occurrences/VulnerabilityCard.js
@@ -21,6 +21,7 @@ import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import LabelWithValue from "components/LabelWithValue";
 import ToggleCard from "components/ToggleCard";
+import Text from "components/Text";
 
 const getIconRepresentation = (severity) => {
   let iconCount = 1;
@@ -52,12 +53,14 @@ const VulnerabilityCard = ({ vulnerability }) => {
             className={styles.cardTitle}
           />
           <div className={styles.severity}>
-            <p>
-              Severity{" "}
-              {vulnerability.effectiveSeverity === "SEVERITY_UNSPECIFIED"
-                ? "N/A"
-                : vulnerability.effectiveSeverity}
-            </p>
+            <LabelWithValue
+              label={"Severity"}
+              value={
+                vulnerability.effectiveSeverity === "SEVERITY_UNSPECIFIED"
+                  ? "N/A"
+                  : vulnerability.effectiveSeverity
+              }
+            />
             {getIconRepresentation(vulnerability.effectiveSeverity)}
           </div>
         </div>
@@ -65,7 +68,9 @@ const VulnerabilityCard = ({ vulnerability }) => {
       content={
         <div>
           {vulnerability.description && (
-            <p className={styles.leftMargin}>{vulnerability.description}</p>
+            <Text.Body1 className={styles.leftMargin}>
+              {vulnerability.description}
+            </Text.Body1>
           )}
           <LabelWithValue
             label={"More details"}

--- a/components/occurrences/VulnerabilityOccurrenceDetails.js
+++ b/components/occurrences/VulnerabilityOccurrenceDetails.js
@@ -23,44 +23,47 @@ import { getVulnerabilityBreakdown } from "utils/occurrence-utils";
 import OccurrenceCodeModal from "./OccurrenceCodeModal";
 import VulnerabilityCard from "./VulnerabilityCard";
 import ExternalLink from "components/ExternalLink";
+import Text from "components/Text";
 
 const VulnerabilityOccurrenceDetails = ({ occurrence }) => {
   return (
     <div>
       <div className={styles.detailSummary}>
         <div>
-          <p className={styles.title}>
+          <Text.Body1>
             {occurrence.notes?.shortDescription || "Vulnerability Scan"}
-          </p>
+          </Text.Body1>
           {occurrence.notes?.longDescription && (
-            <p className={styles.vulnerabilitySubtext}>
+            <Text.Body2 className={styles.vulnerabilitySubtext}>
               {occurrence.notes?.longDescription}
-            </p>
+            </Text.Body2>
           )}
           {occurrence.completed ? (
             <>
-              <p>{occurrence.vulnerabilities.length} vulnerabilities found</p>
-              <p className={styles.vulnerabilitySubtext}>
+              <Text.Body2>
+                {occurrence.vulnerabilities.length} vulnerabilities found
+              </Text.Body2>
+              <Text.Body2 className={styles.vulnerabilitySubtext}>
                 {getVulnerabilityBreakdown(occurrence.vulnerabilities)}
-              </p>
+              </Text.Body2>
             </>
           ) : (
-            <p>Scan In Progress</p>
+            <Text.Body2>Scan In Progress</Text.Body2>
           )}
           {occurrence.notes?.relatedUrl?.map((url) => (
             <ExternalLink key={url.url} href={url.url} label={url.label} />
           ))}
         </div>
         <div className={styles.rightDetails}>
-          <p className={styles.timestamps}>
+          <Text.Body2 className={styles.timestamps}>
             Started {dayjs(occurrence.started).format(DATE_TIME_FORMAT)}
-          </p>
-          <p className={styles.timestamps}>
+          </Text.Body2>
+          <Text.Body2 className={styles.timestamps}>
             Completed{" "}
             {occurrence.completed
               ? dayjs(occurrence.completed).format(DATE_TIME_FORMAT)
               : "N/A"}
-          </p>
+          </Text.Body2>
           <OccurrenceCodeModal json={occurrence.originals} />
         </div>
       </div>

--- a/components/playground/EvaluationResult.js
+++ b/components/playground/EvaluationResult.js
@@ -24,6 +24,7 @@ import Modal from "components/Modal";
 import { copy } from "utils/shared-utils";
 import Code from "components/Code";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const EvaluationResult = ({ results }) => {
   const { theme } = useTheme();
@@ -41,12 +42,12 @@ const EvaluationResult = ({ results }) => {
         {results.pass ? (
           <div className={styles.evaluationResults}>
             <Icon name={ICON_NAMES.BADGE_CHECK} size={"large"} />
-            <p>The resource passed the policy.</p>
+            <Text.Body1>The resource passed the policy.</Text.Body1>
           </div>
         ) : (
           <div className={styles.failedEvaluationResults}>
             <Icon name={ICON_NAMES.EXCLAMATION} size={"large"} />
-            <p>The resource failed the policy.</p>
+            <Text.Body1>The resource failed the policy.</Text.Body1>
           </div>
         )}
         <div className={styles.violations}>
@@ -54,12 +55,14 @@ const EvaluationResult = ({ results }) => {
             const outcome = violation.pass ? "pass" : "fail";
             return (
               <React.Fragment key={violation.id}>
-                <p className={`${styles.violationResult} ${styles[outcome]}`}>
+                <Text.Body1
+                  className={`${styles.violationResult} ${styles[outcome]}`}
+                >
                   {outcome}
-                </p>
-                <p>
+                </Text.Body1>
+                <Text.Body1>
                   {violation.message || "Rule message not specified in policy"}
-                </p>
+                </Text.Body1>
               </React.Fragment>
             );
           })}

--- a/components/playground/PolicySearchAndResults.js
+++ b/components/playground/PolicySearchAndResults.js
@@ -34,6 +34,7 @@ import { ICON_NAMES } from "utils/icon-utils";
 import Drawer from "components/Drawer";
 import useDebouncedValue from "hooks/useDebouncedValue";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const PolicySearchAndResults = ({ setPolicy, clearEvaluation }) => {
   const [policySearch, setPolicySearch] = useState(false);
@@ -105,8 +106,12 @@ const PolicySearchAndResults = ({ setPolicy, clearEvaluation }) => {
                   {data.map((result) => (
                     <div className={`${styles.searchCard}`} key={result.id}>
                       <div>
-                        <p className={styles.cardHeader}>{result.name}</p>
-                        <p className={styles.cardText}>{result.description}</p>
+                        <Text.Body1 className={styles.cardHeader}>
+                          {result.name}
+                        </Text.Body1>
+                        <Text.Body2 className={styles.cardText}>
+                          {result.description}
+                        </Text.Body2>
                       </div>
                       <Button
                         onClick={() => {
@@ -135,7 +140,7 @@ const PolicySearchAndResults = ({ setPolicy, clearEvaluation }) => {
                   )}
                 </>
               ) : (
-                <p>{`No policies found matching "${state.policySearchTerm}"`}</p>
+                <Text.Body1>{`No policies found matching "${state.policySearchTerm}"`}</Text.Body1>
               )}
             </Loading>
           )}

--- a/components/playground/ResourceSearchAndResults.js
+++ b/components/playground/ResourceSearchAndResults.js
@@ -34,6 +34,7 @@ import useDebouncedValue from "hooks/useDebouncedValue";
 import { useAppState } from "providers/appState";
 import { stateActions } from "reducers/appState";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const ResourceSearchAndResults = ({ selectedResource, onResourceSelect }) => {
   const [resourceSearch, setResourceSearch] = useState(!!selectedResource);
@@ -99,7 +100,9 @@ const ResourceSearchAndResults = ({ selectedResource, onResourceSelect }) => {
                   return (
                     <div className={`${styles.searchCard}`} key={id}>
                       <div>
-                        <p className={styles.cardHeader}>{name}</p>
+                        <Text.Body1 className={styles.cardHeader}>
+                          {name}
+                        </Text.Body1>
                         <LabelWithValue
                           label={"Type"}
                           value={type}
@@ -144,7 +147,7 @@ const ResourceSearchAndResults = ({ selectedResource, onResourceSelect }) => {
                 )}
               </>
             ) : (
-              <p>{`No resources found matching "${state.searchTerm}"`}</p>
+              <Text.Body1>{`No resources found matching "${state.resourceSearchTerm}"`}</Text.Body1>
             )}
           </Loading>
         )}

--- a/components/playground/ResourceVersionSearchAndResults.js
+++ b/components/playground/ResourceVersionSearchAndResults.js
@@ -32,6 +32,7 @@ import useDebouncedValue from "hooks/useDebouncedValue";
 import { useAppState } from "providers/appState";
 import { stateActions } from "reducers/appState";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const ResourceVersionSearchAndResults = ({
   selectedResource,
@@ -131,7 +132,7 @@ const ResourceVersionSearchAndResults = ({
               )}
             </>
           ) : (
-            <p>{`No versions found matching "${state.resourceVersionSearchTerm}"`}</p>
+            <Text.Body1>{`No versions found matching "${state.resourceVersionSearchTerm}"`}</Text.Body1>
           )}
         </Loading>
       )}

--- a/components/playground/SelectedPolicy.js
+++ b/components/playground/SelectedPolicy.js
@@ -18,13 +18,13 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Playground.module.scss";
 import Code from "components/Code";
-import textStyles from "styles/modules/Typography.module.scss";
 import LabelWithValue from "components/LabelWithValue";
 import PolicySearchAndResults from "components/playground/PolicySearchAndResults";
 import Button from "components/Button";
 import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import { copy } from "utils/shared-utils";
+import Text from "components/Text";
 
 const SelectedPolicy = (props) => {
   const { policy, setPolicy, clearEvaluation } = props;
@@ -69,7 +69,7 @@ const SelectedPolicy = (props) => {
       </div>
       {policy ? (
         <>
-          <p className={textStyles.label}>Rego Policy Code</p>
+          <Text.Label as={"p"}>Rego Policy Code</Text.Label>
           <Code
             code={policy.regoContent}
             language={"rego"}
@@ -78,7 +78,9 @@ const SelectedPolicy = (props) => {
           />
         </>
       ) : (
-        <p className={styles.selectToBeginText}>Search for a policy to begin</p>
+        <Text.Body1 className={styles.selectToBeginText}>
+          Search for a policy to begin
+        </Text.Body1>
       )}
     </>
   );

--- a/components/playground/SelectedResource.js
+++ b/components/playground/SelectedResource.js
@@ -17,7 +17,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Playground.module.scss";
-import textStyles from "styles/modules/Typography.module.scss";
 import Code from "components/Code";
 import { useFetch } from "hooks/useFetch";
 import Loading from "components/Loading";
@@ -29,6 +28,7 @@ import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import ResourceSelectionDrawer from "components/playground/ResourceSelectionDrawer";
 import { copy } from "utils/shared-utils";
+import Text from "components/Text";
 
 const SelectedResource = (props) => {
   const { resourceUri, setEvaluationResource, clearEvaluation } = props;
@@ -85,7 +85,7 @@ const SelectedResource = (props) => {
       </div>
       {resourceUri ? (
         <Loading loading={loading}>
-          <p className={textStyles.label}>Occurrence Data</p>
+          <Text.Label as={"p"}>Occurrence Data</Text.Label>
           <Code
             code={formattedOccurrenceData}
             language={"json"}
@@ -94,9 +94,9 @@ const SelectedResource = (props) => {
           />
         </Loading>
       ) : (
-        <p className={styles.selectToBeginText}>
+        <Text.Body1 className={styles.selectToBeginText}>
           Search for a resource to begin
-        </p>
+        </Text.Body1>
       )}
     </>
   );

--- a/components/policies/PolicyAssignments.js
+++ b/components/policies/PolicyAssignments.js
@@ -23,6 +23,7 @@ import { useTheme } from "providers/theme";
 import { useFetch } from "hooks/useFetch";
 import Button from "components/Button";
 import { useRouter } from "next/router";
+import Text from "components/Text";
 
 const PolicyAssignments = ({ policy }) => {
   const { theme } = useTheme();
@@ -61,9 +62,9 @@ const PolicyAssignments = ({ policy }) => {
             })}
           </>
         ) : (
-          <p className={styles.noAssignmentsMessage}>
+          <Text.Body1 className={styles.noAssignmentsMessage}>
             This policy is not assigned to any policy groups.
-          </p>
+          </Text.Body1>
         )}
       </Loading>
     </div>

--- a/components/policies/PolicyBreadcrumbs.js
+++ b/components/policies/PolicyBreadcrumbs.js
@@ -20,6 +20,7 @@ import Link from "next/link";
 import { useAppState } from "providers/appState";
 import { SEARCH_ALL } from "utils/constants";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const getSearchTermText = (searchTerm) => {
   if (searchTerm === SEARCH_ALL) {
@@ -41,8 +42,8 @@ const PolicyBreadcrumbs = () => {
 
   return (
     <div className={`${styles[theme]} ${styles.breadcrumbs}`}>
-      <p className={styles.rootCrumb}>Policy Search</p>
-      <p className={styles.rootCrumb}>/</p>
+      <Text.Body1 className={styles.rootCrumb}>Policy Search</Text.Body1>
+      <Text.Body1 className={styles.rootCrumb}>/</Text.Body1>
       <Link href={`/policies?search=${encodeURIComponent(policySearchTerm)}`}>
         <a>{getSearchTermText(policySearchTerm)}</a>
       </Link>

--- a/components/policies/PolicyDetails.js
+++ b/components/policies/PolicyDetails.js
@@ -17,9 +17,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/PolicyDetails.module.scss";
-import textStyles from "styles/modules/Typography.module.scss";
 import Code from "components/Code";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const PolicyDetails = ({ policy }) => {
   const { theme } = useTheme();
@@ -27,7 +27,7 @@ const PolicyDetails = ({ policy }) => {
   return (
     <div className={`${styles[theme]} ${styles.container}`}>
       <div className={styles.regoContainer}>
-        <p className={textStyles.label}>Rego Policy Code</p>
+        <Text.Label as={"p"}>Rego Policy Code</Text.Label>
         <Code
           code={policy.regoContent}
           language={"rego"}

--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -249,7 +249,7 @@ const PolicyForm = ({
         </div>
       </Modal>
       <PageHeader>
-        <h1>{title}</h1>
+        <Text.Heading1>{title}</Text.Heading1>
       </PageHeader>
       <form onSubmit={onSubmit} className={`${styles.form} ${styles[theme]}`}>
         <div className={styles.policyInputsContainer}>

--- a/components/policies/PolicyForm.js
+++ b/components/policies/PolicyForm.js
@@ -33,6 +33,7 @@ import CodeEditor from "components/CodeEditor";
 import { mutate } from "swr";
 import TextArea from "components/TextArea";
 import * as Diff from "diff";
+import Text from "components/Text";
 
 const PolicyForm = ({
   title,
@@ -185,9 +186,9 @@ const PolicyForm = ({
         onClose={() => setShowDeleteModal(false)}
         title={"Confirm Policy Deletion"}
       >
-        <p className={styles.confirmDeleteText}>
+        <Text.Body1 className={styles.confirmDeleteText}>
           Are you sure you want to delete this policy?
-        </p>
+        </Text.Body1>
         <div className={styles.modalActionButtons}>
           <Button
             label={"Cancel"}
@@ -208,14 +209,14 @@ const PolicyForm = ({
         onClose={() => setShowUpdateModal(false)}
         title={"Policy Update Message"}
       >
-        <p className={styles.updateMessageText}>
+        <Text.Body1 className={styles.updateMessageText}>
           By updating the Rego Policy Code, you are creating a new version of
           this policy.
-        </p>
-        <p className={styles.updateMessageText}>
+        </Text.Body1>
+        <Text.Body1 className={styles.updateMessageText}>
           Attach an optional message to this version of the policy, describing
           the changes that were made.
-        </p>
+        </Text.Body1>
         <TextArea
           name={"message"}
           label={"Policy Update Message"}
@@ -284,7 +285,7 @@ const PolicyForm = ({
             rows={10}
             onBlur={validateField}
           />
-          <p className={styles.documentation}>
+          <Text.Caption as={"p"} className={styles.documentation}>
             Need help formulating? Check out the{" "}
             <ExternalLink
               href={
@@ -293,7 +294,7 @@ const PolicyForm = ({
               label={"Rego documentation"}
             />
             .
-          </p>
+          </Text.Caption>
           <div className={styles.policyValidationContainer}>
             <Button
               label={"Validate Policy"}

--- a/components/policies/PolicyHistory.js
+++ b/components/policies/PolicyHistory.js
@@ -24,6 +24,7 @@ import { DATE_TIME_FORMAT } from "utils/constants";
 import Button from "components/Button";
 import styles from "styles/modules/PolicyHistory.module.scss";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const PolicyHistory = ({ policy }) => {
   const { theme } = useTheme();
@@ -48,10 +49,14 @@ const PolicyHistory = ({ policy }) => {
                         index === 0 ? " (latest)" : ""
                       }`}
                     />
-                    <p className={styles.versionMessage}>{version.message}</p>
+                    <Text.Body2 className={styles.versionMessage}>
+                      {version.message}
+                    </Text.Body2>
                   </div>
                   <div>
-                    <p>{dayjs(version.created).format(DATE_TIME_FORMAT)}</p>
+                    <Text.Body2>
+                      {dayjs(version.created).format(DATE_TIME_FORMAT)}
+                    </Text.Body2>
                   </div>
                 </div>
               );

--- a/components/policies/PolicySearchResult.js
+++ b/components/policies/PolicySearchResult.js
@@ -23,6 +23,7 @@ import { stateActions } from "reducers/appState";
 import styles from "styles/modules/SearchResult.module.scss";
 import LabelWithValue from "components/LabelWithValue";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const PolicySearchResult = ({ searchResult }) => {
   const { name, description, id } = searchResult;
@@ -46,7 +47,7 @@ const PolicySearchResult = ({ searchResult }) => {
           value={name}
           className={styles.cardHeader}
         />
-        <p className={styles.cardText}>{description}</p>
+        <Text.Body2 className={styles.cardText}>{description}</Text.Body2>
       </div>
       <Button onClick={onClick} label={"View Policy"} />
     </div>

--- a/components/policies/PolicyValidationResult.js
+++ b/components/policies/PolicyValidationResult.js
@@ -21,6 +21,7 @@ import { ICON_NAMES } from "utils/icon-utils";
 import Icon from "components/Icon";
 import Code from "components/Code";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const PolicyValidationResult = ({ validation }) => {
   const { theme } = useTheme();
@@ -33,13 +34,13 @@ const PolicyValidationResult = ({ validation }) => {
       {validation.isValid ? (
         <div className={`${styles[theme]} ${styles.validationResults}`}>
           <Icon name={ICON_NAMES.BADGE_CHECK} />
-          <p>This policy passes validation.</p>
+          <Text.Body1>This policy passes validation.</Text.Body1>
         </div>
       ) : (
         <div className={`${styles[theme]} ${styles.failedResultsContainer}`}>
           <div className={styles.validationResults}>
             <Icon name={ICON_NAMES.EXCLAMATION} />
-            <p>This policy failed validation.</p>
+            <Text.Body1>This policy failed validation.</Text.Body1>
           </div>
           {validation.errors?.length ? (
             <Code

--- a/components/policy-groups/PolicyAssignmentCard.js
+++ b/components/policy-groups/PolicyAssignmentCard.js
@@ -19,13 +19,14 @@ import PropTypes from "prop-types";
 import styles from "styles/modules/PolicyAssignmentCard.module.scss";
 import LabelWithValue from "components/LabelWithValue";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const PolicyAssignmentCard = ({ policy, actions }) => {
   const { theme } = useTheme();
   return (
     <div className={`${styles.assignmentCard} ${styles[theme]}`}>
       <div>
-        <LabelWithValue value={policy.policyName} />
+        <Text.Value>{policy.policyName}</Text.Value>
         <LabelWithValue label={"Version"} value={policy.policyVersion} />
       </div>
       {actions}

--- a/components/policy-groups/PolicyGroupForm.js
+++ b/components/policy-groups/PolicyGroupForm.js
@@ -28,6 +28,7 @@ import { showError, showSuccess } from "utils/toast-utils";
 import { stateActions } from "reducers/appState";
 import { useAppState } from "providers/appState";
 import { StatusCodes } from "http-status-codes";
+import Text from "components/Text";
 
 const PolicyGroupForm = (props) => {
   const {
@@ -133,10 +134,14 @@ const PolicyGroupForm = (props) => {
               disabled={!creatingNewPolicyGroup}
             />
             {creatingNewPolicyGroup && (
-              <p className={styles.hint} spacing={"Policy Group Name"}>
+              <Text.Caption
+                as={"p"}
+                className={styles.hint}
+                spacing={"Policy Group Name"}
+              >
                 <span>Please note:</span> Policy Group Name cannot be changed
                 after creation.
-              </p>
+              </Text.Caption>
             )}
             <Input
               name={"description"}
@@ -188,7 +193,7 @@ const PolicyGroupForm = (props) => {
           {creatingNewPolicyGroup && (
             <>
               <div>
-                <h2>Policy Group Name Guidelines</h2>
+                <Text.Body1 as={"h2"}>Policy Group Name Guidelines</Text.Body1>
                 <ul>
                   <li>Must be unique</li>
                   <li>Lowercase</li>
@@ -198,7 +203,7 @@ const PolicyGroupForm = (props) => {
                 </ul>
               </div>
               <div>
-                <p>Examples</p>
+                <Text.Body1 as={"h3"}>Examples</Text.Body1>
                 <code>development_3</code>
                 <code>pci-requirements</code>
                 <code>docker_images_prod</code>

--- a/components/policy-groups/PolicyGroupForm.js
+++ b/components/policy-groups/PolicyGroupForm.js
@@ -114,7 +114,7 @@ const PolicyGroupForm = (props) => {
   return (
     <>
       <PageHeader>
-        <h1>{title}</h1>
+        <Text.Heading1>{title}</Text.Heading1>
       </PageHeader>
       <div className={`${styles.pageContainer} ${styles[theme]}`}>
         <form onSubmit={onSubmit} className={styles.form}>
@@ -193,7 +193,7 @@ const PolicyGroupForm = (props) => {
           {creatingNewPolicyGroup && (
             <>
               <div>
-                <Text.Body1 as={"h2"}>Policy Group Name Guidelines</Text.Body1>
+                <Text.Heading2>Policy Group Name Guidelines</Text.Heading2>
                 <ul>
                   <li>Must be unique</li>
                   <li>Lowercase</li>
@@ -203,7 +203,7 @@ const PolicyGroupForm = (props) => {
                 </ul>
               </div>
               <div>
-                <Text.Body1 as={"h3"}>Examples</Text.Body1>
+                <Text.Heading3>Examples</Text.Heading3>
                 <code>development_3</code>
                 <code>pci-requirements</code>
                 <code>docker_images_prod</code>

--- a/components/policy-groups/PolicySearchAndResults.js
+++ b/components/policy-groups/PolicySearchAndResults.js
@@ -32,6 +32,7 @@ import useDebouncedValue from "hooks/useDebouncedValue";
 import { createSearchFilter } from "utils/shared-utils";
 import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
+import Text from "components/Text";
 
 const PolicySearchAndResults = ({ onAssign, assignedToGroup }) => {
   const [policySearch, setPolicySearch] = useState(false);
@@ -98,15 +99,17 @@ const PolicySearchAndResults = ({ onAssign, assignedToGroup }) => {
                   return (
                     <div className={`${styles.searchCard}`} key={result.id}>
                       <div>
-                        <p className={styles.cardHeader}>{result.name}</p>
+                        <Text.Body1 className={styles.cardHeader}>
+                          {result.name}
+                        </Text.Body1>
                         {result.description && (
-                          <p className={styles.cardText}>
+                          <Text.Body2 className={styles.cardText}>
                             {result.description}
-                          </p>
+                          </Text.Body2>
                         )}
-                        <p className={styles.cardText}>
+                        <Text.Body2 className={styles.cardText}>
                           Latest Version {result.currentVersion}
-                        </p>
+                        </Text.Body2>
                       </div>
                       <Button
                         onClick={() =>
@@ -151,7 +154,7 @@ const PolicySearchAndResults = ({ onAssign, assignedToGroup }) => {
                 )}
               </>
             ) : (
-              <p>{`No policies found matching "${state.policySearchTerm}"`}</p>
+              <Text.Body1>{`No policies found matching "${state.policySearchTerm}"`}</Text.Body1>
             )}
           </Loading>
         )}

--- a/components/policy-groups/PolicyVersionDrawer.js
+++ b/components/policy-groups/PolicyVersionDrawer.js
@@ -27,6 +27,7 @@ import { useTheme } from "providers/theme";
 import LabelWithValue from "components/LabelWithValue";
 import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
+import Text from "components/Text";
 
 const PolicyVersionDrawer = ({
   isOpen,
@@ -47,10 +48,10 @@ const PolicyVersionDrawer = ({
       {assignedPolicy ? (
         <div className={`${styles[theme]}`}>
           <div className={styles.drawerHeader}>
-            <p className={styles.policyName}>{assignedPolicy.policyName}</p>
-            <p className={styles.instructions}>
+            <Text.Heading1>{assignedPolicy.policyName}</Text.Heading1>
+            <Text.Body1 className={styles.instructions}>
               Target a specific version of this policy
-            </p>
+            </Text.Body1>
           </div>
           <Loading loading={loading}>
             {data?.length > 0 ? (

--- a/components/policy-groups/PolicyVersionDrawer.js
+++ b/components/policy-groups/PolicyVersionDrawer.js
@@ -48,10 +48,10 @@ const PolicyVersionDrawer = ({
       {assignedPolicy ? (
         <div className={`${styles[theme]}`}>
           <div className={styles.drawerHeader}>
-            <Text.Heading1>{assignedPolicy.policyName}</Text.Heading1>
-            <Text.Body1 className={styles.instructions}>
+            <Text.Body1>{assignedPolicy.policyName}</Text.Body1>
+            <Text.Body2 className={styles.instructions}>
               Target a specific version of this policy
-            </Text.Body1>
+            </Text.Body2>
           </div>
           <Loading loading={loading}>
             {data?.length > 0 ? (

--- a/components/resources/ChangeVersionDrawer.js
+++ b/components/resources/ChangeVersionDrawer.js
@@ -36,6 +36,7 @@ import ResourceVersionSearchBar from "components/resources/ResourceVersionSearch
 import { useAppState } from "providers/appState";
 import { stateActions } from "reducers/appState";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const ChangeVersionDrawer = (props) => {
   const { isOpen, closeDrawer } = props;
@@ -79,11 +80,11 @@ const ChangeVersionDrawer = (props) => {
     <Drawer isOpen={isOpen} onClose={closeDrawer}>
       <div className={`${styles[theme]}`}>
         <div className={styles.headerContainer}>
-          <p className={styles.resourceName}>{resourceName}</p>
-          <p className={styles.instructions}>
+          <Text.Body1>{resourceName}</Text.Body1>
+          <Text.Body2 className={styles.instructions}>
             Select from the list below to see occurrences related to that
             version
-          </p>
+          </Text.Body2>
         </div>
         <div className={styles.searchContainer}>
           <ResourceVersionSearchBar
@@ -163,9 +164,9 @@ const ChangeVersionDrawer = (props) => {
               )}
             </>
           ) : (
-            <p
+            <Text.Body1
               className={styles.notFoundMessage}
-            >{`No versions found matching the given criteria.`}</p>
+            >{`No versions found matching the given criteria.`}</Text.Body1>
           )}
         </Loading>
       </div>

--- a/components/resources/EvaluationHistory.js
+++ b/components/resources/EvaluationHistory.js
@@ -22,6 +22,7 @@ import { usePaginatedFetch } from "hooks/usePaginatedFetch";
 import Loading from "components/Loading";
 import Button from "components/Button";
 import ResourceEvaluation from "./ResourceEvaluation";
+import Text from "components/Text";
 
 const EvaluationHistory = (props) => {
   const { resourceUri } = props;
@@ -61,9 +62,9 @@ const EvaluationHistory = (props) => {
             )}
           </>
         ) : (
-          <p className={styles.noEvaluationsMessage}>
+          <Text.Body1 className={styles.noEvaluationsMessage}>
             The selected version of this resource has not been evaluated.
-          </p>
+          </Text.Body1>
         )}
       </Loading>
     </div>

--- a/components/resources/PolicyEvaluationDetails.js
+++ b/components/resources/PolicyEvaluationDetails.js
@@ -21,6 +21,7 @@ import { ICON_NAMES } from "utils/icon-utils";
 import Icon from "components/Icon";
 import styles from "styles/modules/PolicyEvaluationDetails.module.scss";
 import ToggleCard from "components/ToggleCard";
+import Text from "components/Text";
 
 const PolicyEvaluationDetails = (props) => {
   const { policyEvaluation } = props;
@@ -44,8 +45,8 @@ const PolicyEvaluationDetails = (props) => {
               className={styles.fail}
             />
           )}
-          <p>{policyEvaluation.policyName}</p>
-          <p>v{policyEvaluation.policyVersion}</p>
+          <Text.Body1>{policyEvaluation.policyName}</Text.Body1>
+          <Text.Body1>v{policyEvaluation.policyVersion}</Text.Body1>
         </div>
       }
       content={
@@ -55,10 +56,12 @@ const PolicyEvaluationDetails = (props) => {
 
             return (
               <div key={violation.id} className={styles.violation}>
-                <p className={`${styles[outcome]} ${styles.violationResult}`}>
+                <Text.Body1
+                  className={`${styles[outcome]} ${styles.violationResult}`}
+                >
                   {outcome}
-                </p>
-                <p>{violation.message}</p>
+                </Text.Body1>
+                <Text.Body1>{violation.message}</Text.Body1>
               </div>
             );
           })}

--- a/components/resources/ResourceBreadcrumbs.js
+++ b/components/resources/ResourceBreadcrumbs.js
@@ -19,6 +19,7 @@ import styles from "styles/modules/Breadcrumbs.module.scss";
 import Link from "next/link";
 import { SEARCH_ALL } from "utils/constants";
 import { useAppState } from "providers/appState";
+import Text from "components/Text";
 
 const getSearchTermText = (searchTerm) => {
   if (searchTerm === SEARCH_ALL) {
@@ -39,8 +40,8 @@ const ResourceBreadcrumbs = () => {
 
   return (
     <div className={styles.breadcrumbs}>
-      <p className={styles.rootCrumb}>Resource Search</p>
-      <p className={styles.rootCrumb}>/</p>
+      <Text.Body1 className={styles.rootCrumb}>Resource Search</Text.Body1>
+      <Text.Body1 className={styles.rootCrumb}>/</Text.Body1>
       <Link
         href={`/resources?search=${encodeURIComponent(resourceSearchTerm)}`}
       >

--- a/components/resources/ResourceEvaluation.js
+++ b/components/resources/ResourceEvaluation.js
@@ -25,6 +25,7 @@ import LabelWithValue from "components/LabelWithValue";
 import dayjs from "dayjs";
 import { DATE_TIME_FORMAT } from "utils/constants";
 import ToggleCard from "components/ToggleCard";
+import Text from "components/Text";
 
 const ResourceEvaluation = (props) => {
   const { evaluation } = props;
@@ -45,7 +46,7 @@ const ResourceEvaluation = (props) => {
             ) : (
               <Icon name={ICON_NAMES.EXCLAMATION} size={"large"} />
             )}
-            <p>{evaluationOutcome}</p>
+            <Text.Body1>{evaluationOutcome}</Text.Body1>
           </div>
           <LabelWithValue
             label={"Policy Group"}
@@ -59,7 +60,9 @@ const ResourceEvaluation = (props) => {
       }
       content={
         <div className={styles.policyEvaluationsContainer}>
-          <p>{evaluation.policyEvaluations.length} Policies Evaluated</p>
+          <Text.Body1>
+            {evaluation.policyEvaluations.length} Policies Evaluated
+          </Text.Body1>
           {evaluation.policyEvaluations.map((policyEvaluation) => {
             return (
               <PolicyEvaluationDetails

--- a/components/shared/DetailsHeader.js
+++ b/components/shared/DetailsHeader.js
@@ -18,6 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/DetailsHeader.module.scss";
 import { useTheme } from "providers/theme";
+import Text from "components/Text";
 
 const DetailsHeader = (props) => {
   const { name, subText, actionButton } = props;
@@ -26,7 +27,7 @@ const DetailsHeader = (props) => {
   return (
     <div className={`${styles[theme]} ${styles.detailsHeader}`}>
       <div>
-        <h1 className={styles.name}>{name}</h1>
+        <Text.Heading1 className={styles.name}>{name}</Text.Heading1>
         {subText}
       </div>
       {actionButton}

--- a/components/shared/SearchBar.js
+++ b/components/shared/SearchBar.js
@@ -22,6 +22,7 @@ import Button from "components/Button";
 import Icon from "components/Icon";
 import { ICON_NAMES } from "utils/icon-utils";
 import { SEARCH_ALL } from "utils/constants";
+import Text from "components/Text";
 
 const SearchBar = (props) => {
   const {
@@ -57,7 +58,9 @@ const SearchBar = (props) => {
           <Icon name={ICON_NAMES.SEARCH} size={"large"} />
         </Button>
       </div>
-      {helpText && <p className={styles.searchHelp}>{helpText}</p>}
+      {helpText && (
+        <Text.Caption className={styles.searchHelp}>{helpText}</Text.Caption>
+      )}
     </form>
   );
 };

--- a/cypress/integration/Resource/resource.js
+++ b/cypress/integration/Resource/resource.js
@@ -79,12 +79,8 @@ Then(/^I see "([^"]*)" Vulnerability occurrence details$/, (resourceName) => {
       if (vulnerability.effectiveSeverity === "SEVERITY_UNSPECIFIED") {
         cy.contains("Severity N/A").should("be.visible");
       } else {
-        cy.contains("Severity").should(
-          "be.visible"
-        );
-        cy.contains(vulnerability.effectiveSeverity).should(
-          "be.visible"
-        );
+        cy.contains("Severity").should("be.visible");
+        cy.contains(vulnerability.effectiveSeverity).should("be.visible");
       }
 
       cy.contains(vulnerability.packageName).click();

--- a/cypress/integration/Resource/resource.js
+++ b/cypress/integration/Resource/resource.js
@@ -79,7 +79,10 @@ Then(/^I see "([^"]*)" Vulnerability occurrence details$/, (resourceName) => {
       if (vulnerability.effectiveSeverity === "SEVERITY_UNSPECIFIED") {
         cy.contains("Severity N/A").should("be.visible");
       } else {
-        cy.contains(`Severity ${vulnerability.effectiveSeverity}`).should(
+        cy.contains("Severity").should(
+          "be.visible"
+        );
+        cy.contains(vulnerability.effectiveSeverity).should(
           "be.visible"
         );
       }

--- a/pages/404.js
+++ b/pages/404.js
@@ -16,11 +16,12 @@
 
 import React from "react";
 import styles from "styles/modules/Errors.module.scss";
+import Text from "components/Text";
 
 const Custom404 = () => {
   return (
     <div className={styles.container}>
-      <p>404 - Page Not Found</p>
+      <Text.Body1>404 - Page Not Found</Text.Body1>
     </div>
   );
 };

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -17,15 +17,16 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styles from "styles/modules/Errors.module.scss";
+import Text from "components/Text";
 
 const Error = ({ statusCode }) => {
   return (
     <div className={styles.container}>
-      <p>
+      <Text.Body1>
         {statusCode
           ? `An error ${statusCode} occurred on server.`
           : "An error occurred on client."}
-      </p>
+      </Text.Body1>
     </div>
   );
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -25,8 +25,6 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { SEARCH_ALL } from "utils/constants";
 
-import Text from "components/Text";
-
 const Home = () => {
   const { theme } = useTheme();
   const router = useRouter();
@@ -57,14 +55,6 @@ const Home = () => {
   return (
     <div className={`${styles[theme]} ${styles.container}`}>
       <div className={styles.card}>
-        <Text.Heading1>Heading 1</Text.Heading1>
-        <Text.Heading2>Heading 2</Text.Heading2>
-        <Text.Heading3>Heading 3</Text.Heading3>
-        <Text.Body1>Body 1</Text.Body1>
-        <Text.Body2>Body 2</Text.Body2>
-        <Text.Caption>Caption</Text.Caption>
-        <Text.Label>Label</Text.Label>
-        <Text.Value>Value</Text.Value>
         <ResourceSearchBar
           onSubmit={(event) =>
             onSubmit(event, "resources", state.resourceSearchTerm)

--- a/pages/index.js
+++ b/pages/index.js
@@ -25,6 +25,8 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { SEARCH_ALL } from "utils/constants";
 
+import Text from "components/Text";
+
 const Home = () => {
   const { theme } = useTheme();
   const router = useRouter();
@@ -55,6 +57,14 @@ const Home = () => {
   return (
     <div className={`${styles[theme]} ${styles.container}`}>
       <div className={styles.card}>
+        <Text.Heading1>Heading 1</Text.Heading1>
+        <Text.Heading2>Heading 2</Text.Heading2>
+        <Text.Heading3>Heading 3</Text.Heading3>
+        <Text.Body1>Body 1</Text.Body1>
+        <Text.Body2>Body 2</Text.Body2>
+        <Text.Caption>Caption</Text.Caption>
+        <Text.Label>Label</Text.Label>
+        <Text.Value>Value</Text.Value>
         <ResourceSearchBar
           onSubmit={(event) =>
             onSubmit(event, "resources", state.resourceSearchTerm)

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -25,6 +25,7 @@ import { stateActions } from "reducers/appState";
 import PageHeader from "components/layout/PageHeader";
 import SelectedPolicy from "components/playground/SelectedPolicy";
 import SelectedResource from "components/playground/SelectedResource";
+import Text from "components/Text";
 
 const PolicyPlayground = () => {
   const { theme } = useTheme();
@@ -94,9 +95,9 @@ const PolicyPlayground = () => {
     <div className={`${styles[theme]} ${styles.pageContainer}`}>
       <PageHeader>
         <h1>Policy Playground</h1>
-        <p className={styles.instructions}>
+        <Text.Body1 className={styles.instructions}>
           Choose a resource, pick a policy, and evaluate.
-        </p>
+        </Text.Body1>
       </PageHeader>
       <div className={styles.policyContainer}>
         <SelectedPolicy

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -94,7 +94,7 @@ const PolicyPlayground = () => {
   return (
     <div className={`${styles[theme]} ${styles.pageContainer}`}>
       <PageHeader>
-        <h1>Policy Playground</h1>
+        <Text.Heading1>Policy Playground</Text.Heading1>
         <Text.Body1 className={styles.instructions}>
           Choose a resource, pick a policy, and evaluate.
         </Text.Body1>

--- a/pages/policies.js
+++ b/pages/policies.js
@@ -28,6 +28,7 @@ import Button from "components/Button";
 import { usePaginatedFetch } from "hooks/usePaginatedFetch";
 import { DEFAULT_SEARCH_PAGE_SIZE, SEARCH_ALL } from "utils/constants";
 import useDebouncedValue from "hooks/useDebouncedValue";
+import Text from "components/Text";
 
 const Policies = () => {
   const { theme } = useTheme();
@@ -111,7 +112,9 @@ const Policies = () => {
               )}
             </>
           ) : (
-            <span className={styles.noResults}>No policies found</span>
+            <Text.Body1 className={styles.noResults}>
+              No policies found
+            </Text.Body1>
           )}
         </Loading>
       ) : null}

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -32,6 +32,7 @@ import DetailsNavigation from "components/shared/DetailsNavigation";
 import PolicyHistory from "components/policies/PolicyHistory";
 import EvaluateInPlaygroundButton from "components/shared/EvaluateInPlaygroundButton";
 import PolicyAssignments from "components/policies/PolicyAssignments";
+import Text from "components/Text";
 
 const DETAILS = "details";
 const HISTORY = "history";
@@ -96,7 +97,7 @@ const Policy = () => {
             <>
               <DetailsHeader
                 name={policy.name}
-                subText={<p>{policy.description}</p>}
+                subText={<Text.Body2>{policy.description}</Text.Body2>}
                 actionButton={
                   <Button label={"Edit Policy"} onClick={editPolicy} />
                 }
@@ -114,12 +115,10 @@ const Policy = () => {
             </>
           ) : (
             <div className={styles.notFound}>
-              <h1 className={styles.notFound}>
-                No policy found under {`"${id}"`}
-              </h1>
-              <p>
+              <Text.Heading1>No policy found under {`"${id}"`}</Text.Heading1>
+              <Text.Body1>
                 Try <Link href={"/policies"}>searching for a policy</Link>.
-              </p>
+              </Text.Body1>
             </div>
           )}
         </Loading>

--- a/pages/policies/[id]/edit.js
+++ b/pages/policies/[id]/edit.js
@@ -21,6 +21,7 @@ import Loading from "components/Loading";
 import { usePolicy } from "hooks/usePolicy";
 import styles from "styles/modules/Policy.module.scss";
 import Link from "next/link";
+import Text from "components/Text";
 
 const EditPolicy = () => {
   const router = useRouter();
@@ -41,10 +42,10 @@ const EditPolicy = () => {
         />
       ) : (
         <div className={styles.notFound}>
-          <h1 className={styles.notFound}>No policy found under {`"${id}"`}</h1>
-          <p>
+          <Text.Heading1>No policy found under {`"${id}"`}</Text.Heading1>
+          <Text.Body1>
             Try <Link href={"/policies"}>searching for a policy</Link>.
-          </p>
+          </Text.Body1>
         </div>
       )}
     </Loading>

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -24,6 +24,7 @@ import Loading from "components/Loading";
 import styles from "styles/modules/PolicyGroupDashboard.module.scss";
 import { useAppState } from "providers/appState";
 import { stateActions } from "reducers/appState";
+import Text from "components/Text";
 
 const PolicyGroups = () => {
   const { theme } = useTheme();
@@ -77,7 +78,9 @@ const PolicyGroups = () => {
               )}
             </>
           ) : (
-            <p className={styles.noGroupsMessage}>No policy groups exist.</p>
+            <Text.Body1 className={styles.noGroupsMessage}>
+              No policy groups exist.
+            </Text.Body1>
           )}
         </Loading>
       </div>

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -53,7 +53,7 @@ const PolicyGroups = () => {
         className={styles.createNewButton}
       />
       <PageHeader>
-        <h1>Manage Policy Groups</h1>
+        <Text.Heading1>Manage Policy Groups</Text.Heading1>
       </PageHeader>
       <div className={styles.cardsContainer}>
         <Loading loading={loading}>

--- a/pages/policy-groups.js
+++ b/pages/policy-groups.js
@@ -77,7 +77,7 @@ const PolicyGroups = () => {
               )}
             </>
           ) : (
-            <p>No policy groups exist.</p>
+            <p className={styles.noGroupsMessage}>No policy groups exist.</p>
           )}
         </Loading>
       </div>

--- a/pages/policy-groups/[name].js
+++ b/pages/policy-groups/[name].js
@@ -54,7 +54,7 @@ const PolicyGroup = () => {
   return (
     <>
       <PageHeader>
-        <h1>Manage Policy Groups</h1>
+        <Text.Heading1>Manage Policy Groups</Text.Heading1>
       </PageHeader>
       <div className={`${styles[theme]} ${styles.pageContainer}`}>
         <Loading loading={loading}>

--- a/pages/policy-groups/[name].js
+++ b/pages/policy-groups/[name].js
@@ -27,6 +27,7 @@ import { usePolicyGroup } from "hooks/usePolicyGroup";
 import Link from "next/link";
 import PolicyAssignmentCard from "components/policy-groups/PolicyAssignmentCard";
 import { usePolicyGroupAssignments } from "hooks/usePolicyGroupAssignments";
+import Text from "components/Text";
 
 const PolicyGroup = () => {
   const router = useRouter();
@@ -61,11 +62,13 @@ const PolicyGroup = () => {
             <>
               <div className={styles.policyGroupHeader}>
                 <div>
-                  <p className={styles.policyGroupName}>{policyGroup.name}</p>
+                  <Text.Heading1 className={styles.policyGroupName}>
+                    {policyGroup.name}
+                  </Text.Heading1>
                   {policyGroup.description && (
-                    <p className={styles.policyGroupDescription}>
+                    <Text.Body1 className={styles.policyGroupDescription}>
                       {policyGroup.description}
-                    </p>
+                    </Text.Body1>
                   )}
                 </div>
                 <div>
@@ -78,7 +81,9 @@ const PolicyGroup = () => {
               </div>
               <div className={styles.policyGroupDetailsContainer}>
                 <div className={styles.assignmentsHeaderContainer}>
-                  <p className={styles.assignmentsHeader}>Assigned Policies</p>
+                  <Text.Heading2 className={styles.assignmentsHeader}>
+                    Assigned Policies
+                  </Text.Heading2>
                   <Button
                     label={"Edit Assignments"}
                     buttonType={"text"}
@@ -111,20 +116,22 @@ const PolicyGroup = () => {
                       })}
                     </>
                   ) : (
-                    <p className={styles.noAssignments}>
+                    <Text.Body1 className={styles.noAssignments}>
                       No policies are assigned to this policy group.
-                    </p>
+                    </Text.Body1>
                   )}
                 </Loading>
               </div>
             </>
           ) : (
             <div className={styles.notFoundContainer}>
-              <h1>No policy group found under {`"${name}"`}</h1>
-              <p>
+              <Text.Heading1>
+                No policy group found under {`"${name}"`}
+              </Text.Heading1>
+              <Text.Body1>
                 Go to the <Link href={"/policy-groups"}>dashboard</Link> to view
                 all policy groups
-              </p>
+              </Text.Body1>
             </div>
           )}
         </Loading>

--- a/pages/policy-groups/[name]/assignments.js
+++ b/pages/policy-groups/[name]/assignments.js
@@ -33,6 +33,7 @@ import { usePolicyGroupAssignments } from "hooks/usePolicyGroupAssignments";
 import { useAppState } from "providers/appState";
 import { stateActions } from "reducers/appState";
 import { StatusCodes } from "http-status-codes";
+import Text from "components/Text";
 
 const ADD = "ADD";
 const REMOVE = "REMOVE";
@@ -232,91 +233,100 @@ const EditPolicyGroupAssignments = () => {
       <div className={`${styles[theme]} ${styles.pageContainer}`}>
         <Loading loading={loadingPolicyGroup}>
           {policyGroup ? (
-            <div className={styles.contentContainer}>
-              <div className={styles.assignmentsContainer}>
-                <p className={styles.assignmentsHeader}>{policyGroup.name}</p>
-                <p>Assigned Policies</p>
-                <Loading loading={loadingAssignments}>
-                  {assignedToGroup.length > 0 ? (
-                    <>
-                      {assignedToGroup.map((assignment) => {
-                        const hasMultipleVersions =
-                          assignment.policyVersionCount > 1;
-                        return (
-                          <PolicyAssignmentCard
-                            key={assignment.id}
-                            policy={assignment}
-                            actions={
-                              <div className={styles.assignmentActions}>
-                                {hasMultipleVersions && (
+            <>
+              <div className={styles.contentContainer}>
+                <div className={styles.assignmentsContainer}>
+                  <Text.Heading1 className={styles.assignmentsHeader}>
+                    {policyGroup.name}
+                  </Text.Heading1>
+                  <Text.Heading2 className={styles.assignmentsHeader}>
+                    Assigned Policies
+                  </Text.Heading2>
+                  <Loading loading={loadingAssignments}>
+                    {assignedToGroup.length > 0 ? (
+                      <>
+                        {assignedToGroup.map((assignment) => {
+                          const hasMultipleVersions =
+                            assignment.policyVersionCount > 1;
+                          return (
+                            <PolicyAssignmentCard
+                              key={assignment.id}
+                              policy={assignment}
+                              actions={
+                                <div className={styles.assignmentActions}>
+                                  {hasMultipleVersions && (
+                                    <Button
+                                      label={"Change Policy Version"}
+                                      buttonType={"icon"}
+                                      onClick={() => {
+                                        setDrawerPolicy(assignment);
+                                        setShowPolicyVersionDrawer(true);
+                                      }}
+                                      showTooltip
+                                    >
+                                      <Icon
+                                        name={ICON_NAMES.PENCIL}
+                                        size={"large"}
+                                      />
+                                    </Button>
+                                  )}
                                   <Button
-                                    label={"Change Policy Version"}
+                                    label={"Remove Policy Assignment"}
                                     buttonType={"icon"}
-                                    onClick={() => {
-                                      setDrawerPolicy(assignment);
-                                      setShowPolicyVersionDrawer(true);
-                                    }}
+                                    onClick={() => onRemove(assignment)}
                                     showTooltip
                                   >
                                     <Icon
-                                      name={ICON_NAMES.PENCIL}
+                                      name={ICON_NAMES.X_CIRCLE}
                                       size={"large"}
                                     />
                                   </Button>
-                                )}
-                                <Button
-                                  label={"Remove Policy Assignment"}
-                                  buttonType={"icon"}
-                                  onClick={() => onRemove(assignment)}
-                                  showTooltip
-                                >
-                                  <Icon
-                                    name={ICON_NAMES.X_CIRCLE}
-                                    size={"large"}
-                                  />
-                                </Button>
-                              </div>
-                            }
-                          />
-                        );
-                      })}
-                    </>
-                  ) : (
-                    <p>No policies are assigned to this policy group.</p>
-                  )}
-                </Loading>
+                                </div>
+                              }
+                            />
+                          );
+                        })}
+                      </>
+                    ) : (
+                      <Text.Body1>
+                        No policies are assigned to this policy group.
+                      </Text.Body1>
+                    )}
+                  </Loading>
+                </div>
+                <PolicySearchAndResults
+                  onAssign={onAssign}
+                  assignedToGroup={assignedToGroup}
+                />
               </div>
-              <PolicySearchAndResults
-                onAssign={onAssign}
-                assignedToGroup={assignedToGroup}
-              />
-            </div>
+              <div className={styles.actionButtonsContainer}>
+                <Button
+                  label={"Save Assignments"}
+                  type={"button"}
+                  onClick={onSubmit}
+                  loading={loadingForm}
+                />
+                <Button
+                  label={"Cancel"}
+                  buttonType={"text"}
+                  type={"button"}
+                  onClick={router.back}
+                  disabled={loadingForm}
+                />
+              </div>
+            </>
           ) : (
             <div className={styles.notFoundContainer}>
-              <h1>No policy group found under {`"${name}"`}</h1>
-              <p>
+              <Text.Heading1>
+                No policy group found under {`"${name}"`}
+              </Text.Heading1>
+              <Text.Body1>
                 Go to the <Link href={"/policy-groups"}>dashboard</Link> to view
                 all policy groups
-              </p>
+              </Text.Body1>
             </div>
           )}
         </Loading>
-
-        <div className={styles.actionButtonsContainer}>
-          <Button
-            label={"Save Assignments"}
-            type={"button"}
-            onClick={onSubmit}
-            loading={loadingForm}
-          />
-          <Button
-            label={"Cancel"}
-            buttonType={"text"}
-            type={"button"}
-            onClick={router.back}
-            disabled={loadingForm}
-          />
-        </div>
       </div>
     </>
   );

--- a/pages/policy-groups/[name]/assignments.js
+++ b/pages/policy-groups/[name]/assignments.js
@@ -219,7 +219,7 @@ const EditPolicyGroupAssignments = () => {
   return (
     <>
       <PageHeader>
-        <h1>Edit Policy Group Assignments</h1>
+        <Text.Heading1>Edit Policy Group Assignments</Text.Heading1>
       </PageHeader>
       <PolicyVersionDrawer
         onClose={() => {

--- a/pages/policy-groups/[name]/edit.js
+++ b/pages/policy-groups/[name]/edit.js
@@ -21,6 +21,7 @@ import PolicyGroupForm from "components/policy-groups/PolicyGroupForm";
 import Loading from "components/Loading";
 import Link from "next/link";
 import styles from "styles/modules/PolicyGroupForm.module.scss";
+import Text from "components/Text";
 
 const EditPolicyGroup = () => {
   const router = useRouter();
@@ -42,11 +43,13 @@ const EditPolicyGroup = () => {
         />
       ) : (
         <div className={styles.notFoundContainer}>
-          <h1>No policy group found under {`"${name}"`}</h1>
-          <p>
+          <Text.Heading1>
+            No policy group found under {`"${name}"`}
+          </Text.Heading1>
+          <Text.Body1>
             Go to the <Link href={"/policy-groups"}>dashboard</Link> to view all
             policy groups
-          </p>
+          </Text.Body1>
         </div>
       )}
     </Loading>

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -29,6 +29,7 @@ import { buildResourceQueryParams } from "utils/resource-utils";
 import useDebouncedValue from "hooks/useDebouncedValue";
 import { useAppState } from "providers/appState";
 import { stateActions } from "reducers/appState";
+import Text from "components/Text";
 
 const Resources = () => {
   const { theme } = useTheme();
@@ -132,7 +133,9 @@ const Resources = () => {
                 )}
               </>
             ) : (
-              <span className={styles.noResults}>No resources found</span>
+              <Text.Body1 className={styles.noResults}>
+                No resources found
+              </Text.Body1>
             )}
           </Loading>
         </>

--- a/pages/resources/[resourceUri].js
+++ b/pages/resources/[resourceUri].js
@@ -35,6 +35,8 @@ import DetailsHeader from "components/shared/DetailsHeader";
 import EvaluateInPlaygroundButton from "components/shared/EvaluateInPlaygroundButton";
 import DetailsNavigation from "components/shared/DetailsNavigation";
 import EvaluationHistory from "components/resources/EvaluationHistory";
+import Text from "components/Text";
+import Link from "next/link";
 
 const EVALUATION_HISTORY = "evaluationHistory";
 const OCCURRENCES = "occurrences";
@@ -153,9 +155,14 @@ const Resource = () => {
               )}
             </>
           ) : (
-            <p className={styles.notFound}>
-              No resource found for <wbr /> {`"${resourceUri}"`}
-            </p>
+            <div className={styles.notFound}>
+              <Text.Heading1>
+                No resource found under {`"${resourceUri}"`}
+              </Text.Heading1>
+              <Text.Body1>
+                Try <Link href={"/resources"}>searching for a resource</Link>.
+              </Text.Body1>
+            </div>
           )}
         </Loading>
       </div>

--- a/styles/modules/ChangeResourceVersionDrawer.module.scss
+++ b/styles/modules/ChangeResourceVersionDrawer.module.scss
@@ -24,12 +24,7 @@
   text-align: center;
 }
 
-.resourceName {
-  font-weight: 600;
-}
-
 .instructions {
-  font-size: 0.8rem;
   margin-top: 0.5rem;
 }
 
@@ -56,7 +51,9 @@
 }
 
 .cardSubtext {
-  font-size: 0.8rem;
+  > * {
+    font-size: 0.875rem;
+  }
 }
 
 .viewMoreResultsButton {

--- a/styles/modules/DetailsHeader.module.scss
+++ b/styles/modules/DetailsHeader.module.scss
@@ -40,8 +40,6 @@
 }
 
 .name {
-  //font-size: 1.25rem;
-  //font-weight: 700;
   margin: 0 auto;
   @include ellipsis(calc(100vw - 5rem));
   text-align: center;

--- a/styles/modules/DetailsHeader.module.scss
+++ b/styles/modules/DetailsHeader.module.scss
@@ -40,8 +40,8 @@
 }
 
 .name {
-  font-size: 1.25rem;
-  font-weight: 700;
+  //font-size: 1.25rem;
+  //font-weight: 700;
   margin: 0 auto;
   @include ellipsis(calc(100vw - 5rem));
   text-align: center;

--- a/styles/modules/Header.module.scss
+++ b/styles/modules/Header.module.scss
@@ -158,15 +158,6 @@ $DESKTOP_NAV_WIDTH: 30vw;
   justify-content: center;
   align-items: flex-start;
 
-  > h1 {
-    font-size: 1rem;
-    font-weight: 600;
-
-    @include tabletAndLarger {
-      font-size: 1.25rem;
-    }
-  }
-
   > * {
     margin-left: 0.75rem;
   }

--- a/styles/modules/Inputs.module.scss
+++ b/styles/modules/Inputs.module.scss
@@ -39,8 +39,6 @@ $PADDING: 0.5rem;
 }
 
 .label {
-  display: block;
-  font-weight: 600;
   padding: 0 $PADDING;
   white-space: nowrap;
 }

--- a/styles/modules/Modal.module.scss
+++ b/styles/modules/Modal.module.scss
@@ -49,11 +49,9 @@ $PADDING: 0.5rem;
   text-align: center;
   width: 100%;
   padding: 0.5rem;
-  font-size: 1.15rem;
 
   @include tabletAndLarger {
     padding: 1rem 2rem;
-    font-size: 1.5rem;
   }
 }
 

--- a/styles/modules/OccurrenceDetails.module.scss
+++ b/styles/modules/OccurrenceDetails.module.scss
@@ -44,9 +44,9 @@ $SIDE_SPACING: 1rem;
   }
 }
 
-.title {
-  font-size: 1.5rem;
-}
+//.title {
+//font-size: 1.5rem;
+//}
 
 .rightMargin {
   margin-right: 0.75rem;
@@ -105,8 +105,6 @@ $SIDE_SPACING: 1rem;
 }
 
 .cardTitle {
-  font-weight: 600;
-  font-size: 1.15rem;
   margin-bottom: 0.5rem;
 }
 
@@ -158,7 +156,7 @@ $SIDE_SPACING: 1rem;
   width: fit-content;
 
   > p {
-    padding: 0.1rem;
+    padding: 0.25rem;
   }
 }
 

--- a/styles/modules/OccurrenceDetails.module.scss
+++ b/styles/modules/OccurrenceDetails.module.scss
@@ -44,10 +44,6 @@ $SIDE_SPACING: 1rem;
   }
 }
 
-//.title {
-//font-size: 1.5rem;
-//}
-
 .rightMargin {
   margin-right: 0.75rem;
 }

--- a/styles/modules/Occurrences.module.scss
+++ b/styles/modules/Occurrences.module.scss
@@ -104,18 +104,14 @@ $INDENTATION: 1rem;
   margin-bottom: 0.25rem;
 }
 
-.previewSubText {
-  font-size: 0.85rem;
+.previewSubText,
+.previewTimestamp {
   margin-left: 0.5rem;
   line-height: 1.5rem;
 
   @include tabletAndLarger {
     margin-left: 1rem;
   }
-}
-
-.previewTimestamp {
-  @extend .previewSubText;
 }
 
 .previewBreakdown {
@@ -140,8 +136,8 @@ $INDENTATION: 1rem;
   font-weight: 600;
   font-size: 1.5rem;
 
-  > p {
-    margin-left: 0.25rem;
+  > span {
+    margin: 0 0.25rem;
   }
 }
 

--- a/styles/modules/PlaygroundSearchAndResults.module.scss
+++ b/styles/modules/PlaygroundSearchAndResults.module.scss
@@ -64,13 +64,7 @@ $GAP: 1rem;
 
 .cardText {
   @extend .cardHeader;
-  font-size: 0.8rem;
   margin-left: 0.5rem;
-  @include ellipsis(calc(100vw - 7rem));
-
-  @include tabletAndLarger {
-    max-width: calc(100vw - 24rem);
-  }
 }
 
 .actionButton,
@@ -89,14 +83,6 @@ $GAP: 1rem;
     box-shadow: $DT_BOX_SHADOW;
   }
 
-  .cardHeader {
-    color: $DT_MAIN_TEXT;
-  }
-
-  .cardText {
-    color: $DT_SUB_TEXT;
-  }
-
   .selectedButton {
     svg,
     p {
@@ -109,14 +95,6 @@ $GAP: 1rem;
   .searchCard {
     background-color: $LT_BACKGROUND_LIGHT;
     box-shadow: $LT_BOX_SHADOW;
-  }
-
-  .cardHeader {
-    color: $LT_MAIN_TEXT;
-  }
-
-  .cardText {
-    color: $LT_SUB_TEXT;
   }
 
   .selectedButton {

--- a/styles/modules/PlaygroundSearchAndResults.module.scss
+++ b/styles/modules/PlaygroundSearchAndResults.module.scss
@@ -65,6 +65,10 @@ $GAP: 1rem;
 .cardText {
   @extend .cardHeader;
   margin-left: 0.5rem;
+
+  > * {
+    font-size: 0.875rem;
+  }
 }
 
 .actionButton,
@@ -83,6 +87,10 @@ $GAP: 1rem;
     box-shadow: $DT_BOX_SHADOW;
   }
 
+  .cardText {
+    color: $DT_SUB_TEXT;
+  }
+
   .selectedButton {
     svg,
     p {
@@ -95,6 +103,10 @@ $GAP: 1rem;
   .searchCard {
     background-color: $LT_BACKGROUND_LIGHT;
     box-shadow: $LT_BOX_SHADOW;
+  }
+
+  .cardText {
+    color: $LT_SUB_TEXT;
   }
 
   .selectedButton {

--- a/styles/modules/Policy.module.scss
+++ b/styles/modules/Policy.module.scss
@@ -21,10 +21,4 @@
 .notFound {
   padding: 2rem 0;
   text-align: center;
-
-  h1 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin: 1rem;
-  }
 }

--- a/styles/modules/PolicyForm.module.scss
+++ b/styles/modules/PolicyForm.module.scss
@@ -77,8 +77,7 @@
 
 .documentation {
   margin-top: 0.25rem;
-  font-size: 0.75rem;
-  color: $MEDIUM_GREY;
+  width: 100%;
   text-align: right;
 }
 

--- a/styles/modules/PolicyGroupAssignments.module.scss
+++ b/styles/modules/PolicyGroupAssignments.module.scss
@@ -127,13 +127,7 @@
 
 .cardText {
   @extend .cardHeader;
-  font-size: 0.8rem;
   margin-left: 0.5rem;
-  @include ellipsis(calc(100vw - 7rem));
-
-  @include tabletAndLarger {
-    max-width: calc(100vw - 24rem);
-  }
 }
 
 .actionButton,
@@ -165,9 +159,9 @@
     box-shadow: $DT_BOX_SHADOW;
   }
 
-  .cardHeader {
-    color: $DT_MAIN_TEXT;
-  }
+  //.cardHeader {
+  //  color: $DT_MAIN_TEXT;
+  //}
 
   .cardText {
     color: $DT_SUB_TEXT;
@@ -180,9 +174,9 @@
     box-shadow: $LT_BOX_SHADOW;
   }
 
-  .cardHeader {
-    color: $LT_MAIN_TEXT;
-  }
+  //.cardHeader {
+  //  color: $LT_MAIN_TEXT;
+  //}
 
   .cardText {
     color: $LT_SUB_TEXT;

--- a/styles/modules/PolicyGroupAssignments.module.scss
+++ b/styles/modules/PolicyGroupAssignments.module.scss
@@ -51,9 +51,7 @@
 }
 
 .assignmentsHeader {
-  margin-bottom: 1rem;
-  font-size: 1.25rem;
-  font-weight: 400;
+  margin: 1rem 0;
 }
 
 .assignmentActions {

--- a/styles/modules/PolicyGroupAssignments.module.scss
+++ b/styles/modules/PolicyGroupAssignments.module.scss
@@ -157,10 +157,6 @@
     box-shadow: $DT_BOX_SHADOW;
   }
 
-  //.cardHeader {
-  //  color: $DT_MAIN_TEXT;
-  //}
-
   .cardText {
     color: $DT_SUB_TEXT;
   }
@@ -171,10 +167,6 @@
     background-color: $LT_BACKGROUND_LIGHT;
     box-shadow: $LT_BOX_SHADOW;
   }
-
-  //.cardHeader {
-  //  color: $LT_MAIN_TEXT;
-  //}
 
   .cardText {
     color: $LT_SUB_TEXT;

--- a/styles/modules/PolicyGroupDashboard.module.scss
+++ b/styles/modules/PolicyGroupDashboard.module.scss
@@ -73,6 +73,12 @@
   }
 }
 
+.noGroupsMessage {
+  text-align: center;
+  margin-top: 3rem;
+  grid-column: 1 / -1;
+}
+
 .darkTheme {
   .policyGroupName {
     color: $DT_LINK;
@@ -85,6 +91,7 @@
 
     &:hover {
       box-shadow: $DT_HOVER_SHADOW;
+      background-color: $DT_BACKGROUND_DARK;
     }
   }
 }
@@ -101,6 +108,7 @@
 
     &:hover {
       box-shadow: $LT_HOVER_SHADOW;
+      background-color: $LT_BACKGROUND_DARK;
     }
   }
 }

--- a/styles/modules/PolicyGroupDetails.module.scss
+++ b/styles/modules/PolicyGroupDetails.module.scss
@@ -42,8 +42,6 @@ $DESKTOP_CONTENT_WIDTH: 50%;
 }
 
 .policyGroupName {
-  font-size: 1.25rem;
-  font-weight: 600;
   margin: 0 auto;
   @include ellipsis(calc(100vw - 5rem));
 
@@ -85,8 +83,6 @@ $DESKTOP_CONTENT_WIDTH: 50%;
 }
 
 .assignmentsHeader {
-  font-size: 1.25rem;
-  font-weight: 400;
   margin: 1rem;
 }
 

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -62,7 +62,8 @@
   padding-left: 1rem;
   border-left: solid 0.25rem transparent;
 
-  h2 {
+  h2,
+  h3 {
     font-weight: 600;
     font-size: 1rem;
   }

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -64,8 +64,8 @@
 
   h2,
   h3 {
-    font-weight: 600;
-    font-size: 1rem;
+    //font-weight: 600;
+    //font-size: 1rem;
   }
 
   > *:not(code) {

--- a/styles/modules/PolicyGroupForm.module.scss
+++ b/styles/modules/PolicyGroupForm.module.scss
@@ -62,12 +62,6 @@
   padding-left: 1rem;
   border-left: solid 0.25rem transparent;
 
-  h2,
-  h3 {
-    //font-weight: 600;
-    //font-size: 1rem;
-  }
-
   > *:not(code) {
     margin: 0.25rem auto;
   }

--- a/styles/modules/PolicyVersionDrawer.module.scss
+++ b/styles/modules/PolicyVersionDrawer.module.scss
@@ -29,12 +29,7 @@
   }
 }
 
-.policyName {
-  font-weight: 600;
-}
-
 .instructions {
-  font-size: 0.8rem;
   margin-top: 0.5rem;
 }
 
@@ -54,7 +49,9 @@
 }
 
 .cardDetails {
-  font-size: 0.8rem;
+  > * {
+    font-size: 0.875rem;
+  }
 }
 
 .viewMoreResultsButton {

--- a/styles/modules/Resource.module.scss
+++ b/styles/modules/Resource.module.scss
@@ -41,7 +41,6 @@
 
 .notFound {
   text-align: center;
-  align-self: center;
-  margin-top: 30vh;
+  padding: 2rem 0;
   @include ellipsis(calc(90vw - 3rem));
 }

--- a/styles/modules/Search.module.scss
+++ b/styles/modules/Search.module.scss
@@ -81,9 +81,7 @@
 }
 
 .searchHelp {
-  font-size: 0.75rem;
-  padding: 0 3rem 0 0;
-  color: $MEDIUM_GREY;
+  padding-right: 3rem;
   text-align: right;
 }
 

--- a/styles/modules/SearchResult.module.scss
+++ b/styles/modules/SearchResult.module.scss
@@ -58,12 +58,10 @@
 
 .cardText {
   @extend .cardHeader;
-  font-size: 0.8rem;
   margin-left: 1rem;
-  @include ellipsis(calc(100vw - 7rem));
 
-  @include tabletAndLarger {
-    max-width: calc(100vw - 24rem);
+  > * {
+    font-size: 0.875rem;
   }
 }
 

--- a/styles/modules/Typography.module.scss
+++ b/styles/modules/Typography.module.scss
@@ -59,16 +59,21 @@
 
 .heading1 {
   font-weight: 500;
-  font-size: 1.75rem;
+  font-size: 1.25rem;
 }
 
 .heading2 {
   font-weight: 400;
-  font-size: 1.5rem;
+  font-size: 1.15rem;
 }
 
 .heading3 {
   font-weight: 600;
+  font-size: 1.125rem;
+}
+
+.body1 {
+  font-size: 1rem;
 }
 
 .body2 {

--- a/styles/modules/Typography.module.scss
+++ b/styles/modules/Typography.module.scss
@@ -58,7 +58,7 @@
 }
 
 .heading1 {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 1.25rem;
 }
 

--- a/styles/modules/Typography.module.scss
+++ b/styles/modules/Typography.module.scss
@@ -21,6 +21,14 @@
   flex-direction: row;
   align-items: center;
   width: fit-content;
+
+  &.darkTheme {
+    color: $DT_LINK;
+  }
+
+  &.lightTheme {
+    color: $LT_LINK;
+  }
 }
 
 .codeContainer {
@@ -34,6 +42,10 @@
   display: flex;
   flex-direction: row;
   width: fit-content;
+
+  .value {
+    margin-left: 0.5rem;
+  }
 }
 
 .verticalLabelWithValueContainer {
@@ -45,19 +57,47 @@
   }
 }
 
-.label {
+.heading1 {
+  font-weight: 500;
+}
+
+.heading2 {
   font-weight: 400;
-  padding-right: 0.5rem;
+}
+
+.heading3 {
+  font-weight: 600;
+}
+
+.body2 {
+  font-size: 0.875rem;
+}
+
+.caption {
+  font-size: 0.75rem;
+
+  &.darkTheme {
+    color: $DT_SUB_TEXT;
+  }
+
+  &.lightTheme {
+    color: $LT_SUB_TEXT;
+  }
+}
+
+.label {
+  display: block;
+  font-weight: 600;
+
+  &.darkTheme {
+    color: $DT_MAIN_TEXT;
+  }
+
+  &.lightTheme {
+    color: $LT_MAIN_TEXT;
+  }
 }
 
 .value {
   font-weight: 600;
-}
-
-.darkTheme {
-  color: $DT_LINK;
-}
-
-.lightTheme {
-  color: $LT_LINK;
 }

--- a/styles/modules/Typography.module.scss
+++ b/styles/modules/Typography.module.scss
@@ -59,10 +59,12 @@
 
 .heading1 {
   font-weight: 500;
+  font-size: 1.75rem;
 }
 
 .heading2 {
   font-weight: 400;
+  font-size: 1.5rem;
 }
 
 .heading3 {

--- a/test/components/LabelWithValue.spec.js
+++ b/test/components/LabelWithValue.spec.js
@@ -32,18 +32,13 @@ describe("LabelWithValue", () => {
   it("should render the label", () => {
     const renderedLabel = screen.getByText(label);
     expect(renderedLabel).toBeInTheDocument();
-    expect(renderedLabel).toHaveClass("label");
+    expect(renderedLabel).toHaveClass("body1");
   });
 
   it("should render the value", () => {
     const renderedValue = screen.getByText(value);
     expect(renderedValue).toBeInTheDocument();
     expect(renderedValue).toHaveClass("value");
-  });
-
-  it("should not render the label if it is not specified", () => {
-    rerender(<LabelWithValue label={null} value={value} />);
-    expect(screen.getByText(value).previousElementSibling).toBeNull();
   });
 
   it("should return null if there is no value specified", () => {

--- a/test/components/Text.spec.js
+++ b/test/components/Text.spec.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2021 The Rode Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Text from "components/Text";
+
+describe("Text", () => {
+  let children;
+
+  beforeEach(() => {
+    children = chance.string();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should pass additional classes to the underlying component", () => {
+    const additionalClass = chance.string();
+    render(<Text.Label className={additionalClass}>{children}</Text.Label>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass(additionalClass);
+  });
+
+  it("should pass additional props to the underlying component", () => {
+    const propValue = chance.string({ alpha: true });
+    render(<Text.Label hello={propValue}>{children}</Text.Label>);
+
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveAttribute("hello", propValue);
+  });
+
+  it("should render the primary Heading", () => {
+    render(<Text.Heading1>{children}</Text.Heading1>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("heading1");
+  });
+
+  it("should render the secondary Heading", () => {
+    render(<Text.Heading2>{children}</Text.Heading2>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("heading2");
+  });
+
+  it("should render the third Heading", () => {
+    render(<Text.Heading3>{children}</Text.Heading3>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("heading3");
+  });
+
+  it("should render the Label", () => {
+    render(<Text.Label>{children}</Text.Label>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("label");
+  });
+
+  it("should render the Value", () => {
+    render(<Text.Value>{children}</Text.Value>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("value");
+  });
+
+  it("should render the primary Body text", () => {
+    render(<Text.Body1>{children}</Text.Body1>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("body1");
+  });
+
+  it("should render the secondary Body text", () => {
+    render(<Text.Body2>{children}</Text.Body2>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("body2");
+  });
+
+  it("should render the caption", () => {
+    render(<Text.Caption>{children}</Text.Caption>);
+    const rendered = screen.getByText(children);
+    expect(rendered).toBeInTheDocument();
+    expect(rendered).toHaveClass("caption");
+  });
+});

--- a/test/components/occurrences/BuildOccurrenceDetails.spec.js
+++ b/test/components/occurrences/BuildOccurrenceDetails.spec.js
@@ -43,7 +43,6 @@ describe("BuildOccurrenceDetails", () => {
   });
 
   it("should display the summary details of the build", () => {
-    expect(screen.getByText("Build")).toBeInTheDocument();
     expect(screen.getByText(/view source/i))
       .toBeInTheDocument()
       .toHaveAttribute("href", occurrence.sourceUri);

--- a/test/components/occurrences/DeploymentOccurrenceDetails.spec.js
+++ b/test/components/occurrences/DeploymentOccurrenceDetails.spec.js
@@ -42,7 +42,6 @@ describe("DeploymentOccurrenceDetails", () => {
   });
 
   it("should display the summary details of the deployment", () => {
-    expect(screen.getByText("Deployment")).toBeInTheDocument();
     expect(screen.getByText(/deployed to/i)).toBeInTheDocument();
     expect(
       screen.getByText(`Started ${occurrence.deploymentStart}`)

--- a/test/components/occurrences/VulnerabilityCard.spec.js
+++ b/test/components/occurrences/VulnerabilityCard.spec.js
@@ -38,8 +38,9 @@ describe("VulnerabilityCard", () => {
   it("should show the common details for the vulnerability", () => {
     expect(screen.getByText("Package")).toBeInTheDocument();
     expect(screen.getByText(vulnerability.packageName)).toBeInTheDocument();
+    expect(screen.getByText("Severity")).toBeInTheDocument();
     expect(
-      screen.getByText(`Severity ${vulnerability.effectiveSeverity}`)
+      screen.getByText(vulnerability.effectiveSeverity)
     ).toBeInTheDocument();
 
     expect(
@@ -55,7 +56,7 @@ describe("VulnerabilityCard", () => {
         screen.getByRole("button", { name: "Toggle Card Details" })
       );
 
-      expect(screen.getByText(/severity n\/a/i)).toBeInTheDocument();
+      expect(screen.getByText(/n\/a/i)).toBeInTheDocument();
       expect(screen.getAllByTitle("Fire")).toHaveLength(1);
     });
 
@@ -66,7 +67,7 @@ describe("VulnerabilityCard", () => {
         screen.getByRole("button", { name: "Toggle Card Details" })
       );
 
-      expect(screen.getByText(/severity critical/i)).toBeInTheDocument();
+      expect(screen.getByText(/critical/i)).toBeInTheDocument();
       expect(screen.getAllByTitle("Fire")).toHaveLength(3);
     });
 
@@ -77,7 +78,7 @@ describe("VulnerabilityCard", () => {
         screen.getByRole("button", { name: "Toggle Card Details" })
       );
 
-      expect(screen.getByText(/severity high/i)).toBeInTheDocument();
+      expect(screen.getByText(/high/i)).toBeInTheDocument();
       expect(screen.getAllByTitle("Fire")).toHaveLength(3);
     });
 
@@ -88,7 +89,7 @@ describe("VulnerabilityCard", () => {
         screen.getByRole("button", { name: "Toggle Card Details" })
       );
 
-      expect(screen.getByText(/severity medium/i)).toBeInTheDocument();
+      expect(screen.getByText(/medium/i)).toBeInTheDocument();
       expect(screen.getAllByTitle("Fire")).toHaveLength(2);
     });
 
@@ -99,7 +100,7 @@ describe("VulnerabilityCard", () => {
         screen.getByRole("button", { name: "Toggle Card Details" })
       );
 
-      expect(screen.getByText(/severity low/i)).toBeInTheDocument();
+      expect(screen.getByText(/low/i)).toBeInTheDocument();
       expect(screen.getAllByTitle("Fire")).toHaveLength(1);
     });
   });

--- a/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
+++ b/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
@@ -102,10 +102,11 @@ describe("VulnerabilityOccurrenceDetails", () => {
   });
 
   it("should show a card for each vulnerability found", () => {
-    occurrence.vulnerabilities.forEach((vuln) => {
+    occurrence.vulnerabilities.forEach((vuln, index) => {
       expect(screen.getByText(vuln.packageName)).toBeInTheDocument();
+      expect(screen.getAllByText("Severity")[index]).toBeInTheDocument();
       expect(
-        screen.queryAllByText(`Severity ${vuln.effectiveSeverity}`)[0]
+        screen.getAllByText(vuln.effectiveSeverity)[0]
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
Closes #144 

Adds some basic typography components to cover the common use cases in the application. They are only dictating the font size and font weight with the exception of `<Text.Caption/>` and `<Text.Label/>` since those are universally colored for consistency. Some pieces of text still need additional classes to help with colors/padding/margin, but those styles are generally isolated to the specific component's file.

You can see what the types look like in this pic, as well as what using the component will render as in the DOM. You can override what the element will render to by specifying the `as="elementType"` prop. Check out the `<LabelWithValue/>` component for an example of that.

<img width="475" alt="Screen Shot 2021-07-06 at 4 54 11 PM" src="https://user-images.githubusercontent.com/25139211/124671859-bc835780-de7b-11eb-9ab9-dbb97f6f833d.png">
