### PR TITLE
Usability Requests

### DIFF
--- a/components/Text.js
+++ b/components/Text.js
@@ -57,7 +57,7 @@ BaseText.propTypes = {
     PropTypes.string,
     PropTypes.object,
     PropTypes.node,
-  ]).isRequired,
+  ]),
   style: PropTypes.oneOf([
     "heading1",
     "heading2",

--- a/components/policies/PolicyHistory.js
+++ b/components/policies/PolicyHistory.js
@@ -18,13 +18,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import { usePaginatedFetch } from "hooks/usePaginatedFetch";
 import Loading from "components/Loading";
-import LabelWithValue from "components/LabelWithValue";
 import dayjs from "dayjs";
 import { DATE_TIME_FORMAT } from "utils/constants";
 import Button from "components/Button";
 import styles from "styles/modules/PolicyHistory.module.scss";
 import { useTheme } from "providers/theme";
 import Text from "components/Text";
+import ToggleCard from "components/ToggleCard";
+import Code from "components/Code";
 
 const PolicyHistory = ({ policy }) => {
   const { theme } = useTheme();
@@ -41,24 +42,33 @@ const PolicyHistory = ({ policy }) => {
           <>
             {data.map((version, index) => {
               return (
-                <div key={version.version} className={styles.versionCard}>
-                  <div>
-                    <LabelWithValue
-                      label={"Policy Version"}
-                      value={`v${version.version}${
-                        index === 0 ? " (latest)" : ""
-                      }`}
-                    />
-                    <Text.Body2 className={styles.versionMessage}>
-                      {version.message}
-                    </Text.Body2>
-                  </div>
-                  <div>
-                    <Text.Body2>
-                      {dayjs(version.created).format(DATE_TIME_FORMAT)}
-                    </Text.Body2>
-                  </div>
-                </div>
+                <ToggleCard
+                  key={version.version}
+                  className={styles.historyCard}
+                  header={
+                    <div className={styles.versionCard}>
+                      <div className={styles.versionHeaderDetails}>
+                        <Text.Value className={styles.version}>{`v${
+                          version.version
+                        }${index === 0 ? " (latest)" : ""}`}</Text.Value>
+                        <Text.Body2 className={styles.versionMessage}>
+                          {version.message}
+                        </Text.Body2>
+                      </div>
+                      <div>
+                        <Text.Body2>
+                          {dayjs(version.created).format(DATE_TIME_FORMAT)}
+                        </Text.Body2>
+                      </div>
+                    </div>
+                  }
+                  content={
+                    <div className={styles.versionDetails}>
+                      <Text.Label as={"p"}>Rego Policy Code</Text.Label>
+                      <Code language={"rego"} code={version.regoContent} />
+                    </div>
+                  }
+                />
               );
             })}
           </>

--- a/components/resources/PolicyEvaluationDetails.js
+++ b/components/resources/PolicyEvaluationDetails.js
@@ -22,6 +22,7 @@ import Icon from "components/Icon";
 import styles from "styles/modules/PolicyEvaluationDetails.module.scss";
 import ToggleCard from "components/ToggleCard";
 import Text from "components/Text";
+import Link from "next/link";
 
 const PolicyEvaluationDetails = (props) => {
   const { policyEvaluation } = props;
@@ -45,8 +46,12 @@ const PolicyEvaluationDetails = (props) => {
               className={styles.fail}
             />
           )}
-          <Text.Body1>{policyEvaluation.policyName}</Text.Body1>
-          <Text.Body1>v{policyEvaluation.policyVersion}</Text.Body1>
+          <Text.Body1>
+            <Link href={`/policies/${policyEvaluation.policyVersionId}`}>
+              {policyEvaluation.policyName}
+            </Link>
+          </Text.Body1>
+          <Text.Value>v{policyEvaluation.policyVersion}</Text.Value>
         </div>
       }
       content={

--- a/components/resources/ResourceEvaluation.js
+++ b/components/resources/ResourceEvaluation.js
@@ -26,6 +26,7 @@ import dayjs from "dayjs";
 import { DATE_TIME_FORMAT } from "utils/constants";
 import ToggleCard from "components/ToggleCard";
 import Text from "components/Text";
+import Link from "next/link";
 
 const ResourceEvaluation = (props) => {
   const { evaluation } = props;
@@ -50,7 +51,15 @@ const ResourceEvaluation = (props) => {
           </div>
           <LabelWithValue
             label={"Policy Group"}
-            value={evaluation.policyGroup}
+            value={
+              <Link
+                href={`/policy-groups/${encodeURIComponent(
+                  evaluation.policyGroup
+                )}`}
+              >
+                {evaluation.policyGroup}
+              </Link>
+            }
           />
           <LabelWithValue
             label={"Completed"}

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -96,8 +96,13 @@ const Policy = () => {
           {policy ? (
             <>
               <DetailsHeader
-                name={policy.name}
-                subText={<Text.Body2>{policy.description}</Text.Body2>}
+                name={`${policy.name} v${policy.policyVersion}`}
+                subText={
+                  <div className={styles.policyDetails}>
+                    <Text.Body2>Latest Version {policy.currentVersion}</Text.Body2>
+                    <Text.Body2>{policy.description}</Text.Body2>
+                  </div>
+                }
                 actionButton={
                   <Button label={"Edit Policy"} onClick={editPolicy} />
                 }

--- a/pages/policies/[id].js
+++ b/pages/policies/[id].js
@@ -99,7 +99,9 @@ const Policy = () => {
                 name={`${policy.name} v${policy.policyVersion}`}
                 subText={
                   <div className={styles.policyDetails}>
-                    <Text.Body2>Latest Version {policy.currentVersion}</Text.Body2>
+                    <Text.Body2>
+                      Latest Version {policy.currentVersion}
+                    </Text.Body2>
                     <Text.Body2>{policy.description}</Text.Body2>
                   </div>
                 }

--- a/styles/modules/Policy.module.scss
+++ b/styles/modules/Policy.module.scss
@@ -14,8 +14,24 @@
  * limitations under the License.
  */
 
+@import "styles/mixins";
+
 .pageContainer {
   height: 100%;
+}
+
+.policyDetails {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  > *:not(*:last-of-type) {
+    margin-right: 1rem;
+  }
+
+  @include tabletAndLarger {
+    flex-direction: row;
+  }
 }
 
 .notFound {

--- a/styles/modules/PolicyHistory.module.scss
+++ b/styles/modules/PolicyHistory.module.scss
@@ -17,33 +17,66 @@
 @import "styles/constants";
 @import "styles/mixins";
 
-.versionCard {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 0.5rem;
+.historyCard {
   width: 95%;
   margin: 1rem auto 0;
 
   &:last-of-type {
     margin-bottom: 1rem;
   }
+}
+
+.versionCard {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-right: 1rem;
+  padding: 0.5rem;
+  width: 100%;
+  height: 100%;
 
   @include tabletAndLarger {
     flex-direction: row;
     justify-content: space-between;
-    padding: 2rem 3rem;
   }
 }
 
-.versionMessage {
-  margin: 1rem 0 0 1rem;
+.versionHeaderDetails {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  > * {
+    margin: 0.5rem;
+  }
+
+  @include tabletAndLarger {
+    flex-direction: row;
+  }
+}
+
+.versionDetails {
+  width: 95%;
+  margin: 0.5rem auto;
+
+  > p {
+    margin-bottom: 0.25rem;
+  }
 }
 
 .darkTheme {
-  .versionCard {
+  .historyCard {
     background-color: $DT_BACKGROUND_MEDIUM;
+  }
+
+  .versionCard {
+    &:hover {
+      .version {
+        color: $LAGOON;
+      }
+    }
   }
 
   .versionMessage {
@@ -52,8 +85,16 @@
 }
 
 .lightTheme {
-  .versionCard {
+  .historyCard {
     background-color: $LT_BACKGROUND_LIGHT;
+  }
+
+  .versionCard {
+    &:hover {
+      .version {
+        color: $DEEP_SEA;
+      }
+    }
   }
 
   .versionMessage {

--- a/test/components/policies/PolicyHistory.spec.js
+++ b/test/components/policies/PolicyHistory.spec.js
@@ -37,12 +37,13 @@ describe("PolicyHistory", () => {
         () => ({
           message: chance.string(),
           created: chance.timestamp(),
+          regoContent: chance.string(),
         }),
         chance.d4()
       )
       .map((version, index) => ({
         ...version,
-        version: index,
+        version: index + 1,
       }));
     goToNextPage = jest.fn();
     format = jest.fn();
@@ -83,9 +84,19 @@ describe("PolicyHistory", () => {
     });
   });
 
+  it("should show the rego content of the version when the user selects a version to view", () => {
+    policyVersions.forEach((version) => {
+      userEvent.click(
+        screen.getByText(`v${version.version}`, { exact: false })
+      );
+      expect(
+        screen.getByText(version.regoContent, { exact: false })
+      ).toBeInTheDocument();
+    });
+  });
+
   it("should indicate the latest version to the user", () => {
     policyVersions.forEach((version, index) => {
-      expect(screen.getAllByText("Policy Version")[index]).toBeInTheDocument();
       expect(
         screen.getByText(`v${version.version}${index === 0 ? " (latest)" : ""}`)
       ).toBeInTheDocument();

--- a/test/components/resources/PolicyEvaluationDetails.spec.js
+++ b/test/components/resources/PolicyEvaluationDetails.spec.js
@@ -27,6 +27,7 @@ describe("PolicyEvaluationDetails", () => {
       pass: chance.bool(),
       policyName: chance.string(),
       policyVersion: chance.d4(),
+      policyVersionId: chance.string(),
       created: chance.timestamp(),
       violations: [
         {
@@ -52,7 +53,12 @@ describe("PolicyEvaluationDetails", () => {
   });
 
   it("should render details about the evaluation", () => {
-    expect(screen.getByText(policyEvaluation.policyName)).toBeInTheDocument();
+    const renderedPolicyName = screen.getByText(policyEvaluation.policyName);
+    expect(renderedPolicyName).toBeInTheDocument();
+    expect(renderedPolicyName).toHaveAttribute(
+      "href",
+      `/policies/${policyEvaluation.policyVersionId}`
+    );
     expect(
       screen.getByText(`v${policyEvaluation.policyVersion}`)
     ).toBeInTheDocument();

--- a/test/components/resources/ResourceEvaluation.spec.js
+++ b/test/components/resources/ResourceEvaluation.spec.js
@@ -62,7 +62,12 @@ describe("ResourceEvaluation", () => {
   });
 
   it("should render details about the evaluation", () => {
-    expect(screen.getByText(evaluation.policyGroup)).toBeInTheDocument();
+    const renderedPolicyGroup = screen.getByText(evaluation.policyGroup);
+    expect(renderedPolicyGroup).toBeInTheDocument();
+    expect(renderedPolicyGroup).toHaveAttribute(
+      "href",
+      `/policy-groups/${encodeURIComponent(evaluation.policyGroup)}`
+    );
     expect(screen.getByText(evaluation.created)).toBeInTheDocument();
   });
 

--- a/test/pages/policies/[id].spec.js
+++ b/test/pages/policies/[id].spec.js
@@ -55,7 +55,7 @@ describe("Policy Details", () => {
       description: chance.string(),
       regoContent: chance.word({ syllables: 4 }),
       policyVersion: chance.d10(),
-      currentVersion: chance.d10()
+      currentVersion: chance.d10(),
     };
 
     mockUsePolicy = {
@@ -122,10 +122,16 @@ describe("Policy Details", () => {
 
   describe("policy has been found", () => {
     it("should render the policy header", () => {
-      expect(screen.getByText(policy.name, {exact: false})).toBeInTheDocument();
+      expect(
+        screen.getByText(policy.name, { exact: false })
+      ).toBeInTheDocument();
       expect(screen.getByText(policy.description)).toBeInTheDocument();
-      expect(screen.getByText(`v${policy.policyVersion}`, {exact: false})).toBeInTheDocument();
-      expect(screen.getByText(`Latest Version ${policy.currentVersion}`)).toBeInTheDocument();
+      expect(
+        screen.getByText(`v${policy.policyVersion}`, { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(`Latest Version ${policy.currentVersion}`)
+      ).toBeInTheDocument();
 
       const renderedButton = screen.getByText("Edit Policy");
       expect(renderedButton).toBeInTheDocument();

--- a/test/pages/policies/[id].spec.js
+++ b/test/pages/policies/[id].spec.js
@@ -54,6 +54,8 @@ describe("Policy Details", () => {
       name: chance.string(),
       description: chance.string(),
       regoContent: chance.word({ syllables: 4 }),
+      policyVersion: chance.d10(),
+      currentVersion: chance.d10()
     };
 
     mockUsePolicy = {
@@ -120,8 +122,10 @@ describe("Policy Details", () => {
 
   describe("policy has been found", () => {
     it("should render the policy header", () => {
-      expect(screen.getByText(policy.name)).toBeInTheDocument();
+      expect(screen.getByText(policy.name, {exact: false})).toBeInTheDocument();
       expect(screen.getByText(policy.description)).toBeInTheDocument();
+      expect(screen.getByText(`v${policy.policyVersion}`, {exact: false})).toBeInTheDocument();
+      expect(screen.getByText(`Latest Version ${policy.currentVersion}`)).toBeInTheDocument();
 
       const renderedButton = screen.getByText("Edit Policy");
       expect(renderedButton).toBeInTheDocument();


### PR DESCRIPTION
per Robert, closes #150 

* Viewing a policy now shows the current version you are viewing, as well as the latest version of the policy
  * When coming from search, these will always match because we show the latest version of the policy
  * When coming from resource evaluation history, these may not match depending on the policy group assignment
* Viewing policy history, you can now click on the version to toggle the rego content (similar to the vulnerability cards on a resource)
* Resource Evaluation History now links to the policy groups and policy at the evaluated version.