### PR TITLE
Use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:14.17.1-alpine3.12
-
+FROM node:14.17.1-alpine3.12 as builder
+ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /usr/src/app
 
 # Installing dependencies
@@ -7,7 +7,6 @@ COPY package.json /usr/src/app/
 COPY yarn.lock /usr/src/app/
 
 RUN yarn install --production
-RUN npx next telemetry disable
 
 # Copying source files
 COPY . .
@@ -15,5 +14,12 @@ COPY . .
 # Building app
 RUN yarn build
 
-# Running the app
+###
+
+FROM node:14.17.1-alpine3.12
+WORKDIR /usr/src/app
+ENV NODE_ENV=production
+
+COPY --from=builder /usr/src/app /usr/src/app
+
 ENTRYPOINT ["node", "index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14.17.1-alpine3.12 as builder
+ARG NODE_TAG=14.17.1-alpine3.12
+FROM node:${NODE_TAG} as builder
 ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /usr/src/app
 
@@ -16,10 +17,10 @@ RUN yarn build
 
 ###
 
-FROM node:14.17.1-alpine3.12
+FROM node:${NODE_TAG}
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
 
-COPY --from=builder /usr/src/app /usr/src/app
+COPY --from=builder /usr/src/app .
 
 ENTRYPOINT ["node", "index.mjs"]


### PR DESCRIPTION
I noticed our UI images were a bit large and it seems like the main issue is the yarn cache. Switching to a multi-stage build ensures the cache doesn't end up in the final image for a ~50% size reduction. Likely some additional improvements could be made, but I think this is a good first step. 

```
$ docker images rode-ui
REPOSITORY   TAG        IMAGE ID       CREATED              SIZE
rode-ui      local-v2   8e9a87a7f602   About a minute ago   189MB
rode-ui      local      01433c3b8182   15 minutes ago       420MB
```