### PR TITLE
add missing request body to policy assignment POST

### DIFF
--- a/pages/api/policy-groups/[name]/assignments.js
+++ b/pages/api/policy-groups/[name]/assignments.js
@@ -75,7 +75,7 @@ export default async (req, res) => {
 
       const response = await post(
         `${rodeUrl}/v1alpha1/policies/${requestBody.policyVersionId}/assignments/${name}`,
-        requestBody,
+        null,
         req.accessToken
       );
 

--- a/pages/api/policy-groups/[name]/assignments.js
+++ b/pages/api/policy-groups/[name]/assignments.js
@@ -75,6 +75,7 @@ export default async (req, res) => {
 
       const response = await post(
         `${rodeUrl}/v1alpha1/policies/${requestBody.policyVersionId}/assignments/${name}`,
+        requestBody,
         req.accessToken
       );
 

--- a/test/pages/api/policy-groups/[name]/assignments.spec.js
+++ b/test/pages/api/policy-groups/[name]/assignments.spec.js
@@ -180,6 +180,7 @@ describe("/api/policy-groups/[name]/assignments", () => {
             `${config.get("rode.url")}/v1alpha1/policies/${
               assignment.policyVersionId
             }/assignments/${name}`,
+            assignment,
             accessToken
           );
       });

--- a/test/pages/api/policy-groups/[name]/assignments.spec.js
+++ b/test/pages/api/policy-groups/[name]/assignments.spec.js
@@ -180,7 +180,7 @@ describe("/api/policy-groups/[name]/assignments", () => {
             `${config.get("rode.url")}/v1alpha1/policies/${
               assignment.policyVersionId
             }/assignments/${name}`,
-            assignment,
+            null,
             accessToken
           );
       });


### PR DESCRIPTION
apparently we were not sending a request body when creating policy assignments.  looking through the history, we never did, but I swear I've done this before and have seen it working in the past.