### PR TITLE
display message in vulnerability occurrence summary when discovery analysis failed

### DIFF
--- a/components/occurrences/SecureOccurrenceSection.js
+++ b/components/occurrences/SecureOccurrenceSection.js
@@ -49,26 +49,26 @@ const SecureOccurrenceSection = ({ occurrences }) => {
               : "In Progress"
           }
           subText={
-            occurrence.completed ? occurrence.analysisStatus === "FINISHED_FAILED" ? (
-              <>
-                <Text.Body2
-                  as={"span"}
-                >Analysis Failed</Text.Body2>
-              </>
-            ) : (
-              <>
-                <Text.Body2
-                  as={"span"}
-                >{`${occurrence.vulnerabilities.length} vulnerabilities found`}</Text.Body2>
-                {!!occurrence.vulnerabilities.length && (
+            occurrence.completed ? (
+              occurrence.analysisStatus === "FINISHED_FAILED" ? (
+                <>
+                  <Text.Body2 as={"span"}>Analysis Failed</Text.Body2>
+                </>
+              ) : (
+                <>
                   <Text.Body2
-                    className={styles.previewBreakdown}
                     as={"span"}
-                  >{`${getVulnerabilityBreakdown(
-                    occurrence.vulnerabilities
-                  )}`}</Text.Body2>
-                )}
-              </>
+                  >{`${occurrence.vulnerabilities.length} vulnerabilities found`}</Text.Body2>
+                  {!!occurrence.vulnerabilities.length && (
+                    <Text.Body2
+                      className={styles.previewBreakdown}
+                      as={"span"}
+                    >{`${getVulnerabilityBreakdown(
+                      occurrence.vulnerabilities
+                    )}`}</Text.Body2>
+                  )}
+                </>
+              )
             ) : null
           }
         />

--- a/components/occurrences/SecureOccurrenceSection.js
+++ b/components/occurrences/SecureOccurrenceSection.js
@@ -49,7 +49,13 @@ const SecureOccurrenceSection = ({ occurrences }) => {
               : "In Progress"
           }
           subText={
-            occurrence.completed ? (
+            occurrence.completed ? occurrence.analysisStatus === "FINISHED_FAILED" ? (
+              <>
+                <Text.Body2
+                  as={"span"}
+                >Analysis Failed</Text.Body2>
+              </>
+            ) : (
               <>
                 <Text.Body2
                   as={"span"}

--- a/components/occurrences/VulnerabilityOccurrenceDetails.js
+++ b/components/occurrences/VulnerabilityOccurrenceDetails.js
@@ -38,19 +38,21 @@ const VulnerabilityOccurrenceDetails = ({ occurrence }) => {
               {occurrence.notes?.longDescription}
             </Text.Body2>
           )}
-          {occurrence.completed ? occurrence.analysisStatus === "FINISHED_FAILED" ? (
-            <>
-              <Text.Body2>Analysis Failed</Text.Body2>
-            </>
-          ) : (
-            <>
-              <Text.Body2>
-                {occurrence.vulnerabilities.length} vulnerabilities found
-              </Text.Body2>
-              <Text.Body2 className={styles.vulnerabilitySubtext}>
-                {getVulnerabilityBreakdown(occurrence.vulnerabilities)}
-              </Text.Body2>
-            </>
+          {occurrence.completed ? (
+            occurrence.analysisStatus === "FINISHED_FAILED" ? (
+              <>
+                <Text.Body2>Analysis Failed</Text.Body2>
+              </>
+            ) : (
+              <>
+                <Text.Body2>
+                  {occurrence.vulnerabilities.length} vulnerabilities found
+                </Text.Body2>
+                <Text.Body2 className={styles.vulnerabilitySubtext}>
+                  {getVulnerabilityBreakdown(occurrence.vulnerabilities)}
+                </Text.Body2>
+              </>
+            )
           ) : (
             <Text.Body2>Scan In Progress</Text.Body2>
           )}

--- a/components/occurrences/VulnerabilityOccurrenceDetails.js
+++ b/components/occurrences/VulnerabilityOccurrenceDetails.js
@@ -38,7 +38,11 @@ const VulnerabilityOccurrenceDetails = ({ occurrence }) => {
               {occurrence.notes?.longDescription}
             </Text.Body2>
           )}
-          {occurrence.completed ? (
+          {occurrence.completed ? occurrence.analysisStatus === "FINISHED_FAILED" ? (
+            <>
+              <Text.Body2>Analysis Failed</Text.Body2>
+            </>
+          ) : (
             <>
               <Text.Body2>
                 {occurrence.vulnerabilities.length} vulnerabilities found

--- a/pages/api/utils/occurrence-utils.js
+++ b/pages/api/utils/occurrence-utils.js
@@ -141,6 +141,7 @@ const matchAndMapVulnerabilities = (occurrences, notes) => {
           originals: {
             occurrences: [startScan, ...matchingVulnerabilities],
           },
+          analysisStatus: undefined,
         };
       }
 
@@ -153,6 +154,7 @@ const matchAndMapVulnerabilities = (occurrences, notes) => {
         originals: {
           occurrences: [startScan, endScan, ...matchingVulnerabilities],
         },
+        analysisStatus: endScan.discovered.discovered.analysisStatus,
       };
     })
     .filter((val) => val);

--- a/test/components/occurrences/SecureOccurrenceSection.spec.js
+++ b/test/components/occurrences/SecureOccurrenceSection.spec.js
@@ -101,5 +101,17 @@ describe("SecureOccurrenceSection", () => {
       );
       expect(renderedVulnerabilityCount).toHaveLength(occurrences.length - 1);
     });
+
+    it("should render a failure message when the analysis failed", () => {
+      occurrences[0].analysisStatus = "FINISHED_FAILED";
+
+      rerender(<SecureOccurrenceSection occurrences={occurrences} />);
+
+      expect(screen.getByText("Analysis Failed")).toBeInTheDocument();
+      const renderedVulnerabilityCount = screen.queryAllByText(
+        /vulnerabilities found/i
+      );
+      expect(renderedVulnerabilityCount).toHaveLength(occurrences.length - 1);
+    });
   });
 });

--- a/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
+++ b/test/components/occurrences/VulnerabilityOccurrenceDetails.spec.js
@@ -121,4 +121,13 @@ describe("VulnerabilityOccurrenceDetails", () => {
 
     expect(screen.getByText("Completed N/A")).toBeInTheDocument();
   });
+
+  it("should show a failure message when the analysis failed", () => {
+    occurrence.analysisStatus = "FINISHED_FAILED";
+    rerender(<VulnerabilityOccurrenceDetails occurrence={occurrence} />);
+    expect(screen.getByText("Analysis Failed")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/vulnerabilities found/i)
+    ).not.toBeInTheDocument();
+  });
 });

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -89,7 +89,9 @@ describe("occurrence-utils", () => {
           expect(secure).toHaveLength(1);
           expect(secure[0].started).toEqual(startScanOccurrence.createTime);
           expect(secure[0].completed).toEqual(endScanOccurrence.createTime);
-          expect(secure[0].analysisStatus).toEqual(endScanOccurrence.discovered.discovered.analysisStatus);
+          expect(secure[0].analysisStatus).toEqual(
+            endScanOccurrence.discovered.discovered.analysisStatus
+          );
           expect(secure[0].notes).toEqual(notes[noteName]);
           expect(secure[0].originals.occurrences).toContain(
             startScanOccurrence
@@ -181,7 +183,7 @@ describe("occurrence-utils", () => {
           expect(secure).toHaveLength(1);
           expect(secure[0].completed).toBeNull();
           expect(secure[0].vulnerabilities).toHaveLength(0);
-          expect(secure[0].analysisStatus).toBeUndefined()
+          expect(secure[0].analysisStatus).toBeUndefined();
           expect(other).toHaveLength(1);
         });
       });

--- a/test/pages/api/utils/occurrence-utils.spec.js
+++ b/test/pages/api/utils/occurrence-utils.spec.js
@@ -89,6 +89,7 @@ describe("occurrence-utils", () => {
           expect(secure).toHaveLength(1);
           expect(secure[0].started).toEqual(startScanOccurrence.createTime);
           expect(secure[0].completed).toEqual(endScanOccurrence.createTime);
+          expect(secure[0].analysisStatus).toEqual(endScanOccurrence.discovered.discovered.analysisStatus);
           expect(secure[0].notes).toEqual(notes[noteName]);
           expect(secure[0].originals.occurrences).toContain(
             startScanOccurrence
@@ -180,6 +181,7 @@ describe("occurrence-utils", () => {
           expect(secure).toHaveLength(1);
           expect(secure[0].completed).toBeNull();
           expect(secure[0].vulnerabilities).toHaveLength(0);
+          expect(secure[0].analysisStatus).toBeUndefined()
           expect(other).toHaveLength(1);
         });
       });

--- a/test/testing-utils/mocks.js
+++ b/test/testing-utils/mocks.js
@@ -194,6 +194,7 @@ export const createMockMappedVulnerabilityOccurrence = () => {
         createMockOccurrence("VULNERABILITY", sharedTimestamp),
       ],
     },
+    analysisStatus: "FINISHED_SUCCESS",
   };
 };
 


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/3793752/126397955-6e277f27-9546-4a15-8bcc-2699d7e08d8f.png)


after:

![image](https://user-images.githubusercontent.com/3793752/126397850-eb03bdb6-647d-472d-af82-2ce832239ce2.png)
