### PR TITLE
Drop session cookies after refresh failure

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -26,11 +26,11 @@ jobs:
           push: false
   license-check:
     runs-on: ubuntu-latest
-    container: golang:1.15
+    container: golang:1.16
     steps:
       - uses: actions/checkout@v2
       - name: Download License Utility
-        run: go get -u github.com/google/addlicense
+        run: go install github.com/google/addlicense@master
       - name: Check License Headers
         run: |
           shopt -s globstar

--- a/server/middleware.mjs
+++ b/server/middleware.mjs
@@ -60,7 +60,7 @@ export const tokenRefresh = () => async (req, res, next) => {
     } catch (error) {
       console.error("Error refreshing oidc token", error);
 
-      return res.redirect("/login");
+      return res.oidc.logout();
     }
   }
 

--- a/test/server/middleware.spec.js
+++ b/test/server/middleware.spec.js
@@ -125,7 +125,7 @@ describe("middleware", () => {
         expect(response.oidc.logout).not.toHaveBeenCalled();
       });
 
-      it("should end the session ", async () => {
+      it("should end the session", async () => {
         refresh.mockRejectedValue(new Error("refresh failed"));
 
         await tokenRefresh()(request, response, next);

--- a/test/server/middleware.spec.js
+++ b/test/server/middleware.spec.js
@@ -94,7 +94,9 @@ describe("middleware", () => {
         },
       };
       response = {
-        redirect: jest.fn(),
+        oidc: {
+          logout: jest.fn(),
+        },
       };
     });
 
@@ -104,7 +106,7 @@ describe("middleware", () => {
       expect(request.accessToken).toEqual(accessToken);
       expect(next).toHaveBeenCalled();
       expect(refresh).not.toHaveBeenCalled();
-      expect(response.redirect).not.toHaveBeenCalled();
+      expect(response.oidc.logout).not.toHaveBeenCalled();
     });
 
     describe("the token is expired", () => {
@@ -120,19 +122,17 @@ describe("middleware", () => {
         expect(request.accessToken).toEqual(nextAccessToken);
         expect(refresh).toHaveBeenCalled();
         expect(next).toHaveBeenCalled();
-        expect(response.redirect).not.toHaveBeenCalled();
+        expect(response.oidc.logout).not.toHaveBeenCalled();
       });
 
-      it("should redirect the request to the login route if the refresh fails", async () => {
+      it("should end the session ", async () => {
         refresh.mockRejectedValue(new Error("refresh failed"));
 
         await tokenRefresh()(request, response, next);
 
         expect(request.accessToken).toBeUndefined();
         expect(next).not.toHaveBeenCalled();
-        expect(response.redirect)
-          .toHaveBeenCalledTimes(1)
-          .toHaveBeenCalledWith("/login");
+        expect(response.oidc.logout).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
If the request to refresh the access token fails, we try to redirect to login. However, this doesn't drop the existing session cookies so the request gets stuck in loop trying and failing to refresh the token, then redirecting to `/login`. 

This PR changes the middleware to end the session, but doesn't try to reinitiate a login. I tested this by lowering the access token lifespan to 1 minute, invalidating the session in Keycloak, and waiting for a refresh to happen. 

Likely there could be some better UX here, see #167 and likely #165 would be helpful.  