### PR TITLE
Wrap long lines in <Code /> component

### DIFF
--- a/styles/modules/Typography.module.scss
+++ b/styles/modules/Typography.module.scss
@@ -34,6 +34,7 @@
 .codeContainer {
   width: 100%;
   overflow: auto;
+  white-space: pre-wrap;
   padding: 1rem;
   font-family: monospace;
 }


### PR DESCRIPTION
Currently, long lines in the `<Code />` component can either overflow or cause unwanted resizes in flexbox containers.

Before (25% zoom):

![Screen Shot 2021-09-14 at 9 32 40 AM](https://user-images.githubusercontent.com/9082799/133267124-08eca2bb-fb20-4e48-b3e1-f97a3bcf5142.png)

After (100% zoom):

![Screen Shot 2021-09-14 at 9 31 58 AM](https://user-images.githubusercontent.com/9082799/133267248-8b698c9e-fb2b-4b4a-a6f0-74a03e3ea571.png)

You can also see this by looking at the occurrence data on the resource view -- before it overflowed the container, but was hidden:

![Screen Shot 2021-09-14 at 9 30 07 AM](https://user-images.githubusercontent.com/9082799/133267380-92674640-a8bb-4974-81c5-e663e49c82e6.png)

Now it's wrapped:

![Screen Shot 2021-09-14 at 9 29 59 AM](https://user-images.githubusercontent.com/9082799/133267407-86ce84f2-6449-42f3-b7e9-063555d940aa.png)

